### PR TITLE
feature/bbogart_kdar_gensel

### DIFF
--- a/ubana/MicroBooNEWireCell/WireCellAnaTree_module.cc
+++ b/ubana/MicroBooNEWireCell/WireCellAnaTree_module.cc
@@ -98,7 +98,7 @@ public:
   void save_weights(art::Event const& e);
   void save_LEEweights(art::Event const& e);
   void ReadBDTvar(nsm::NuSelectionBDT const& bdt);
-  void ReadSSMBDTvar(art::Ptr<nsm::NuSelectionBDT> bdt);
+  void ReadSSMBDTvar(nsm::NuSelectionBDT const& bdt);
   void ReadKINEvar(nsm::NuSelectionKINE const& kine);
   void nsbeamtiming(art::Event const& e);
   void getPMTwf(art::Event const& e, double maxP[32],double timeP[32],bool Sat[32]);
@@ -3543,8 +3543,8 @@ void WireCellAnaTree::analyze(art::Event const& e)
                 f_match_notFC_DC = c.GetNotFCDC();
                 f_match_charge = c.GetCharge();
                 f_match_energy = c.GetEnergy();
-                f_lm_cluster_length = c->GetLength();
-                f_image_fail = c->GetImageFail();
+                f_lm_cluster_length = c.GetLength();
+                f_image_fail = c.GetImageFail();
 	}
 
         auto const& charge_vec = e.getProduct<std::vector<nsm::NuSelectionCharge>>(fChargeLabel);
@@ -4266,7 +4266,6 @@ void WireCellAnaTree::analyze(art::Event const& e)
 		return;
 	}
         for(nsm::NuSelectionKINE const& kine : *kinehandle) {
-	        ReadSSMKINEvar(kine);
                 if(f_lm_cluster_length>10){
                   ReadKINEvar(kine);
                 }

--- a/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell.sh
+++ b/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell.sh
@@ -30,9 +30,7 @@ cp $wc_input_celltree WCPwork/
 
 echo "set up additional environment for wirecell" | tee -a wirecell.log
 cd WCPwork 
-#setup numpy v1_14_3 -q e17:openblas:p2714b:prof
-#setup libtorch v1_0_1 -q e17:prof
-#setup SparseConvNet 8422a6f -q e17:prof
+
 setup SparseConvNet v01_00_00
 export PYTHONPATH=$WCP_FQ_DIR/python:$PYTHONPATH #may not needed any longer; already appened in uboonecode
 
@@ -56,10 +54,6 @@ do
 	echo "Number of good cells: $numgoodcell" | tee -a ../wirecell.log 
 	if [ x$numgoodcell != x -a "$numgoodcell" = "0" ]; then
       		echo "WARNING: empty 3D image!" | tee -a ../wirecell.log
-		touch nuseldummy_imaging${n}.root
-		touch portdummy_imaging${n}.root
-		rm result_*.root
-		continue	
 	fi
 
 	echo "event $n matching starts."
@@ -71,10 +65,7 @@ do
 		input2=${input1#*result_}
 		echo $input2 | tee -a ../wirecell.log
 		mv $imagingfile imaging_$input2.root
-		#prod-nusel-eval ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -d0 -p1 2>&1 | tee -a ../wirecell.log
-		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -d0 2>&1 | tee -a ../wirecell.log
-		#mv nuselEval*.root nusel_$input2.root
-		#mv port*.root porting_$input2.root
+		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -y1 -d0 2>&1 | tee -a ../wirecell.log
 		warning=`tail -n 1 ../wirecell.log`
 		echo "$warning"
 		if [ "$warning" = "No points! Quit! " ]; then
@@ -82,6 +73,11 @@ do
 			touch nuseldummy_${input2}.root
 			touch portdummy_${input2}.root
 		fi
+                image_fail=`grep "image_fail for ${input2}" ../wirecell.log | awk '{print $1}'`
+                if [ x$image_fail != x -a "$image_fail" = "1" ]; then
+                        mv nuselEval_${input2}.root nuselEvalImageFail_${input2}.root
+                        mv port_${input2}.root portImageFail_${input2}.root
+                fi
 	done
 	echo "event $n matching finished."
 done
@@ -91,6 +87,16 @@ echo "contents in this directory: " | tee -a ../wirecell.log
 ls -t | tee -a ../wirecell.log
 hadd merge.root ./port_*.root
 hadd nuselDATA_WCP.root ./nuselEval_*.root
+#hadd the files without image failures seperatly to make sure the tree structure is good
+for file in nuselEvalImageFail*; do
+    if [[ -f $file ]]; then
+        mv merge.root merge_temp.root
+        mv nuselDATA_WCP.root nuselDATA_WCP_temp.root
+        hadd merge.root merge_temp.root portImageFail*
+        hadd nuselDATA_WCP.root nuselDATA_WCP_temp.root nuselEvalImageFail*
+        break
+    fi
+done
 
 # stage2 (reco2) starts here
 echo "wirecell stage2 starts here"
@@ -126,6 +132,7 @@ do
 		mv $stmfile STM_$stminput2.root
 		### only if in-time match found
 		test_stm STM_$stminput2.root 1>>WCP_STM.log 2>STMerror.log
+                test_stm_kdar STM_$stminput2.root 1>>WCP_STM_KDAR.log 2>STMerror.log
 		cat STMerror.log | tee -a ../wirecell.log 
 	done
 	echo "event $n cosmic rejection finished." | tee -a ../wirecell.log
@@ -147,9 +154,6 @@ do
         echo "WCP cosmic tagger: $wcreco2_runinfo $wcreco2_tag1 $wcreco2_tag2 $wcreco2_tag3 $wcreco2_tag4 $wcreco2_tag5 $wcreco2_tag6 $wcreco2_tag7" | tee -a WCP_analysis.log 
 	if [ -n "$wcreco2_runinfo" ]; then 
         if [ $wcreco2_tag1 != 0 -a $wcreco2_tag2 = 0 -a $wcreco2_tag3 = 0 -a $wcreco2_tag4 = 0 -a $wcreco2_tag5 = 0 -a $wcreco2_tag6 = 0 -a $(echo "$wcreco2_tag7 > 0"|bc) = 1 ]; then
-                #run=`echo $runinfo | awk -F "_" '{print $1}'`
-                #subrun=`echo $runinfo | awk -F "_" '{print $2}'`
-                #event=`echo $runinfo | awk -F "_" '{print $3}'`
 
 		echo "event $n nue starts." | tee -a WCP_analysis.log	
 		wire-cell-prod-nue ./input_data_files/ChannelWireGeometry_v2.txt $wc_input_celltree $n -d0 2>&1 | tee -a WCP_analysis.log
@@ -187,19 +191,12 @@ if [ $wc_nevts1 = $wc_nevts2 -a $wc_nevts1 = $wc_nevts3 -a $wc_nevts1 = $wc_even
 	echo "Good!" | tee -a ../wirecell.log
 else
 	echo "Bad: nusel $wc_nevts1, port $wc_nevts2, stm $wc_nevts3, input $wc_eventcount" | tee -a ../wirecell.log
- 	##touch merge.root ### empty merge.root --> WCP failure	
 	exit 204
 fi
 
-
 mv WCP_STM.log $wc_workdir
+mv WCP_STM_KDAR.log $wc_workdir
 mv WCP_analysis.log $wc_workdir
-# mv imaging*.root $wc_workdir
-# mv nuselDATA_WCP.root $wc_workdir
-# mv merge.root $wc_workdir # to not confuse production system
-                            # keep it in WCPwork, see run_slimmed_port_data.fcl
-# mv nue_*.root $wc_workdir # run_wcpf_port.fcl
-
 cd $wc_workdir
 rm celltreeDATA*.root
 echo "Done! Done! Done!" | tee -a wirecell.log

--- a/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_WCP_00_17_00.sh
+++ b/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_WCP_00_17_00.sh
@@ -30,7 +30,9 @@ cp $wc_input_celltree WCPwork/
 
 echo "set up additional environment for wirecell" | tee -a wirecell.log
 cd WCPwork 
-
+#setup numpy v1_14_3 -q e17:openblas:p2714b:prof
+#setup libtorch v1_0_1 -q e17:prof
+#setup SparseConvNet 8422a6f -q e17:prof
 setup SparseConvNet v01_00_00
 export PYTHONPATH=$WCP_FQ_DIR/python:$PYTHONPATH #may not needed any longer; already appened in uboonecode
 
@@ -47,13 +49,17 @@ touch WCP_analysis.log
 for ((n=0; n<$(($wc_eventcount)); n++))
 do
 	echo "event $n processing starts." | tee -a ../wirecell.log
-	wire-cell-imaging-lmem-celltree ./input_data_files/ChannelWireGeometry_v2.txt $wc_input_celltree $n -d0 -a1 -s2 2>&1 | tee -a ../wirecell.log
+	wire-cell-imaging-lmem-celltree ./input_data_files/ChannelWireGeometry_v2.txt $wc_input_celltree $n -d0 -s2 2>&1 | tee -a ../wirecell.log
 	echo "event $n imaging finished." | tee -a ../wirecell.log
 	###empty images
 	numgoodcell=`tail -n 10 ../wirecell.log | grep "mcell" | awk '{print $5}'`
 	echo "Number of good cells: $numgoodcell" | tee -a ../wirecell.log 
 	if [ x$numgoodcell != x -a "$numgoodcell" = "0" ]; then
       		echo "WARNING: empty 3D image!" | tee -a ../wirecell.log
+		touch nuseldummy_imaging${n}.root
+		touch portdummy_imaging${n}.root
+		rm result_*.root
+		continue	
 	fi
 
 	echo "event $n matching starts."
@@ -65,7 +71,10 @@ do
 		input2=${input1#*result_}
 		echo $input2 | tee -a ../wirecell.log
 		mv $imagingfile imaging_$input2.root
-		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -y1 -d0 2>&1 | tee -a ../wirecell.log
+		#prod-nusel-eval ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -d0 -p1 2>&1 | tee -a ../wirecell.log
+		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -d0 2>&1 | tee -a ../wirecell.log
+		#mv nuselEval*.root nusel_$input2.root
+		#mv port*.root porting_$input2.root
 		warning=`tail -n 1 ../wirecell.log`
 		echo "$warning"
 		if [ "$warning" = "No points! Quit! " ]; then
@@ -73,11 +82,6 @@ do
 			touch nuseldummy_${input2}.root
 			touch portdummy_${input2}.root
 		fi
-                image_fail=`grep "image_fail for ${input2}" ../wirecell.log | awk '{print $1}'`
-                if [ x$image_fail != x -a "$image_fail" = "1" ]; then
-                        mv nuselEval_${input2}.root nuselEvalImageFail_${input2}.root
-                        mv port_${input2}.root portImageFail_${input2}.root
-                fi
 	done
 	echo "event $n matching finished."
 done
@@ -87,16 +91,6 @@ echo "contents in this directory: " | tee -a ../wirecell.log
 ls -t | tee -a ../wirecell.log
 hadd merge.root ./port_*.root
 hadd nuselDATA_WCP.root ./nuselEval_*.root
-#hadd the files without image failures seperatly to make sure the tree structure is good
-for file in nuselEvalImageFail*; do
-    if [[ -f $file ]]; then
-        mv merge.root merge_temp.root
-        mv nuselDATA_WCP.root nuselDATA_WCP_temp.root
-        hadd merge.root merge_temp.root portImageFail*
-        hadd nuselDATA_WCP.root nuselDATA_WCP_temp.root nuselEvalImageFail*
-        break
-    fi
-done
 
 # stage2 (reco2) starts here
 echo "wirecell stage2 starts here"
@@ -132,7 +126,6 @@ do
 		mv $stmfile STM_$stminput2.root
 		### only if in-time match found
 		test_stm STM_$stminput2.root 1>>WCP_STM.log 2>STMerror.log
-                test_stm_kdar STM_$stminput2.root 1>>WCP_STM_KDAR.log 2>STMerror.log
 		cat STMerror.log | tee -a ../wirecell.log 
 	done
 	echo "event $n cosmic rejection finished." | tee -a ../wirecell.log
@@ -154,6 +147,9 @@ do
         echo "WCP cosmic tagger: $wcreco2_runinfo $wcreco2_tag1 $wcreco2_tag2 $wcreco2_tag3 $wcreco2_tag4 $wcreco2_tag5 $wcreco2_tag6 $wcreco2_tag7" | tee -a WCP_analysis.log 
 	if [ -n "$wcreco2_runinfo" ]; then 
         if [ $wcreco2_tag1 != 0 -a $wcreco2_tag2 = 0 -a $wcreco2_tag3 = 0 -a $wcreco2_tag4 = 0 -a $wcreco2_tag5 = 0 -a $wcreco2_tag6 = 0 -a $(echo "$wcreco2_tag7 > 0"|bc) = 1 ]; then
+                #run=`echo $runinfo | awk -F "_" '{print $1}'`
+                #subrun=`echo $runinfo | awk -F "_" '{print $2}'`
+                #event=`echo $runinfo | awk -F "_" '{print $3}'`
 
 		echo "event $n nue starts." | tee -a WCP_analysis.log	
 		wire-cell-prod-nue ./input_data_files/ChannelWireGeometry_v2.txt $wc_input_celltree $n -d0 2>&1 | tee -a WCP_analysis.log
@@ -191,12 +187,19 @@ if [ $wc_nevts1 = $wc_nevts2 -a $wc_nevts1 = $wc_nevts3 -a $wc_nevts1 = $wc_even
 	echo "Good!" | tee -a ../wirecell.log
 else
 	echo "Bad: nusel $wc_nevts1, port $wc_nevts2, stm $wc_nevts3, input $wc_eventcount" | tee -a ../wirecell.log
+ 	##touch merge.root ### empty merge.root --> WCP failure	
 	exit 204
 fi
 
+
 mv WCP_STM.log $wc_workdir
-mv WCP_STM_KDAR.log $wc_workdir
 mv WCP_analysis.log $wc_workdir
+# mv imaging*.root $wc_workdir
+# mv nuselDATA_WCP.root $wc_workdir
+# mv merge.root $wc_workdir # to not confuse production system
+                            # keep it in WCPwork, see run_slimmed_port_data.fcl
+# mv nue_*.root $wc_workdir # run_wcpf_port.fcl
+
 cd $wc_workdir
 rm celltreeDATA*.root
 echo "Done! Done! Done!" | tee -a wirecell.log

--- a/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_numi_WCP_00_17_00.sh
+++ b/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_numi_WCP_00_17_00.sh
@@ -30,7 +30,9 @@ cp $wc_input_celltree WCPwork/
 
 echo "set up additional environment for wirecell" | tee -a wirecell.log
 cd WCPwork 
-
+#setup numpy v1_14_3 -q e17:openblas:p2714b:prof
+#setup libtorch v1_0_1 -q e17:prof
+#setup SparseConvNet 8422a6f -q e17:prof
 setup SparseConvNet v01_00_00
 export PYTHONPATH=$WCP_FQ_DIR/python:$PYTHONPATH #may not needed any longer; already appened in uboonecode
 
@@ -54,6 +56,10 @@ do
 	echo "Number of good cells: $numgoodcell" | tee -a ../wirecell.log 
 	if [ x$numgoodcell != x -a "$numgoodcell" = "0" ]; then
       		echo "WARNING: empty 3D image!" | tee -a ../wirecell.log
+		touch nuseldummy_imaging${n}.root
+		touch portdummy_imaging${n}.root
+		rm result_*.root
+		continue	
 	fi
 
 	echo "event $n matching starts."
@@ -65,7 +71,10 @@ do
 		input2=${input1#*result_}
 		echo $input2 | tee -a ../wirecell.log
 		mv $imagingfile imaging_$input2.root
-		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -y1 -d0 2>&1 | tee -a ../wirecell.log
+		#prod-nusel-eval ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -d0 -p1 2>&1 | tee -a ../wirecell.log
+		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -d0 2>&1 | tee -a ../wirecell.log
+		#mv nuselEval*.root nusel_$input2.root
+		#mv port*.root porting_$input2.root
 		warning=`tail -n 1 ../wirecell.log`
 		echo "$warning"
 		if [ "$warning" = "No points! Quit! " ]; then
@@ -73,11 +82,6 @@ do
 			touch nuseldummy_${input2}.root
 			touch portdummy_${input2}.root
 		fi
-                image_fail=`grep "image_fail for ${input2}" ../wirecell.log | awk '{print $1}'`
-                if [ x$image_fail != x -a "$image_fail" = "1" ]; then
-                        mv nuselEval_${input2}.root nuselEvalImageFail_${input2}.root
-                        mv port_${input2}.root portImageFail_${input2}.root
-                fi
 	done
 	echo "event $n matching finished."
 done
@@ -87,16 +91,6 @@ echo "contents in this directory: " | tee -a ../wirecell.log
 ls -t | tee -a ../wirecell.log
 hadd merge.root ./port_*.root
 hadd nuselDATA_WCP.root ./nuselEval_*.root
-#hadd the files without image failures seperatly to make sure the tree structure is good
-for file in nuselEvalImageFail*; do
-    if [[ -f $file ]]; then
-        mv merge.root merge_temp.root
-        mv nuselDATA_WCP.root nuselDATA_WCP_temp.root
-        hadd merge.root merge_temp.root portImageFail*
-        hadd nuselDATA_WCP.root nuselDATA_WCP_temp.root nuselEvalImageFail*
-        break
-    fi
-done
 
 # stage2 (reco2) starts here
 echo "wirecell stage2 starts here"
@@ -132,7 +126,6 @@ do
 		mv $stmfile STM_$stminput2.root
 		### only if in-time match found
 		test_stm STM_$stminput2.root 1>>WCP_STM.log 2>STMerror.log
-                test_stm_kdar STM_$stminput2.root 1>>WCP_STM_KDAR.log 2>STMerror.log
 		cat STMerror.log | tee -a ../wirecell.log 
 	done
 	echo "event $n cosmic rejection finished." | tee -a ../wirecell.log
@@ -154,6 +147,9 @@ do
         echo "WCP cosmic tagger: $wcreco2_runinfo $wcreco2_tag1 $wcreco2_tag2 $wcreco2_tag3 $wcreco2_tag4 $wcreco2_tag5 $wcreco2_tag6 $wcreco2_tag7" | tee -a WCP_analysis.log 
 	if [ -n "$wcreco2_runinfo" ]; then 
         if [ $wcreco2_tag1 != 0 -a $wcreco2_tag2 = 0 -a $wcreco2_tag3 = 0 -a $wcreco2_tag4 = 0 -a $wcreco2_tag5 = 0 -a $wcreco2_tag6 = 0 -a $(echo "$wcreco2_tag7 > 0"|bc) = 1 ]; then
+                #run=`echo $runinfo | awk -F "_" '{print $1}'`
+                #subrun=`echo $runinfo | awk -F "_" '{print $2}'`
+                #event=`echo $runinfo | awk -F "_" '{print $3}'`
 
 		echo "event $n nue starts." | tee -a WCP_analysis.log	
 		wire-cell-prod-nue ./input_data_files/ChannelWireGeometry_v2.txt $wc_input_celltree $n -d0 2>&1 | tee -a WCP_analysis.log
@@ -191,12 +187,19 @@ if [ $wc_nevts1 = $wc_nevts2 -a $wc_nevts1 = $wc_nevts3 -a $wc_nevts1 = $wc_even
 	echo "Good!" | tee -a ../wirecell.log
 else
 	echo "Bad: nusel $wc_nevts1, port $wc_nevts2, stm $wc_nevts3, input $wc_eventcount" | tee -a ../wirecell.log
+ 	##touch merge.root ### empty merge.root --> WCP failure	
 	exit 204
 fi
 
+
 mv WCP_STM.log $wc_workdir
-mv WCP_STM_KDAR.log $wc_workdir
 mv WCP_analysis.log $wc_workdir
+# mv imaging*.root $wc_workdir
+# mv nuselDATA_WCP.root $wc_workdir
+# mv merge.root $wc_workdir # to not confuse production system
+                            # keep it in WCPwork, see run_slimmed_port_data.fcl
+# mv nue_*.root $wc_workdir # run_wcpf_port.fcl
+
 cd $wc_workdir
 rm celltreeDATA*.root
 echo "Done! Done! Done!" | tee -a wirecell.log

--- a/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_overlay.sh
@@ -30,9 +30,7 @@ cp $wc_input_celltree WCPwork/
 
 echo "set up additional environment for wirecell" | tee -a wirecell.log
 cd WCPwork 
-#setup numpy v1_14_3 -q e17:openblas:p2714b:prof
-#setup libtorch v1_0_1 -q e17:prof
-#setup SparseConvNet 8422a6f -q e17:prof
+
 setup SparseConvNet v01_00_00
 export PYTHONPATH=$WCP_FQ_DIR/python:$PYTHONPATH #may not needed any longer; already appened in uboonecode
 
@@ -56,10 +54,6 @@ do
 	echo "Number of good cells: $numgoodcell" | tee -a ../wirecell.log 
 	if [ x$numgoodcell != x -a "$numgoodcell" = "0" ]; then
       		echo "WARNING: empty 3D image!" | tee -a ../wirecell.log
-		touch nuseldummy_imaging${n}.root
-		touch portdummy_imaging${n}.root
-		rm result_*.root
-		continue	
 	fi
 
 	echo "event $n matching starts."
@@ -71,10 +65,7 @@ do
 		input2=${input1#*result_}
 		echo $input2 | tee -a ../wirecell.log
 		mv $imagingfile imaging_$input2.root
-		#prod-nusel-eval ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -d0 -p1 2>&1 | tee -a ../wirecell.log
-		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -d1 2>&1 | tee -a ../wirecell.log
-		#mv nuselEval*.root nusel_$input2.root
-		#mv port*.root porting_$input2.root
+		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -y1 -d1 2>&1 | tee -a ../wirecell.log
 		warning=`tail -n 1 ../wirecell.log`
 		echo "$warning"
 		if [ "$warning" = "No points! Quit! " ]; then
@@ -82,6 +73,11 @@ do
 			touch nuseldummy_${input2}.root
 			touch portdummy_${input2}.root
 		fi
+                image_fail=`grep "image_fail for ${input2}" ../wirecell.log | awk '{print $1}'`
+                if [ x$image_fail != x -a "$image_fail" = "1" ]; then
+                        mv nuselEval_${input2}.root nuselEvalImageFail_${input2}.root
+                        mv port_${input2}.root portImageFail_${input2}.root
+                fi
 	done
 	echo "event $n matching finished."
 done
@@ -91,6 +87,16 @@ echo "contents in this directory: " | tee -a ../wirecell.log
 ls -t | tee -a ../wirecell.log
 hadd merge.root ./port_*.root
 hadd nuselOVERLAY_WCP.root ./nuselEval_*.root
+#hadd the files without image failures seperatly to make sure the tree structure is good
+for file in nuselEvalImageFail*; do
+    if [[ -f $file ]]; then
+        mv merge.root merge_temp.root
+        mv nuselOVERLAY_WCP.root nuselOVERLAY_WCP_temp.root
+        hadd merge.root merge_temp.root portImageFail*
+        hadd nuselOVERLAY_WCP.root nuselOVERLAY_WCP_temp.root nuselEvalImageFail*
+        break
+    fi
+done
 
 # stage2 (reco2) starts here
 echo "wirecell stage2 starts here"
@@ -126,6 +132,7 @@ do
 		mv $stmfile STM_$stminput2.root
 		### only if in-time match found
 		test_stm STM_$stminput2.root 1>>WCP_STM.log 2>STMerror.log
+                test_stm_kdar STM_$stminput2.root 1>>WCP_STM_KDAR.log 2>STMerror.log
 		cat STMerror.log | tee -a ../wirecell.log 
 	done
 	echo "event $n cosmic rejection finished." | tee -a ../wirecell.log
@@ -147,9 +154,6 @@ do
         echo "WCP cosmic tagger: $wcreco2_runinfo $wcreco2_tag1 $wcreco2_tag2 $wcreco2_tag3 $wcreco2_tag4 $wcreco2_tag5 $wcreco2_tag6 $wcreco2_tag7" | tee -a WCP_analysis.log 
 	if [ -n "$wcreco2_runinfo" ]; then 
         if [ $wcreco2_tag1 != 0 -a $wcreco2_tag2 = 0 -a $wcreco2_tag3 = 0 -a $wcreco2_tag4 = 0 -a $wcreco2_tag5 = 0 -a $wcreco2_tag6 = 0 -a $(echo "$wcreco2_tag7 > 0"|bc) = 1 ]; then
-                #run=`echo $runinfo | awk -F "_" '{print $1}'`
-                #subrun=`echo $runinfo | awk -F "_" '{print $2}'`
-                #event=`echo $runinfo | awk -F "_" '{print $3}'`
 
 		echo "event $n nue starts." | tee -a WCP_analysis.log	
 		wire-cell-prod-nue ./input_data_files/ChannelWireGeometry_v2.txt $wc_input_celltree $n -d0 2>&1 | tee -a WCP_analysis.log
@@ -187,19 +191,12 @@ if [ $wc_nevts1 = $wc_nevts2 -a $wc_nevts1 = $wc_nevts3 -a $wc_nevts1 = $wc_even
 	echo "Good!" | tee -a ../wirecell.log
 else
 	echo "Bad: nusel $wc_nevts1, port $wc_nevts2, stm $wc_nevts3, input $wc_eventcount" | tee -a ../wirecell.log
- 	##touch merge.root ### empty merge.root --> WCP failure	
 	exit 204
 fi
 
-
 mv WCP_STM.log $wc_workdir
+mv WCP_STM_KDAR.log $wc_workdir
 mv WCP_analysis.log $wc_workdir
-# mv imaging*.root $wc_workdir
-# mv nuselDATA_WCP.root $wc_workdir
-# mv merge.root $wc_workdir # to not confuse production system
-                            # keep it in WCPwork, see run_slimmed_port_data.fcl
-# mv nue_*.root $wc_workdir # run_wcpf_port.fcl
-
 cd $wc_workdir
 rm celltreeOVERLAY*.root
 echo "Done! Done! Done!" | tee -a wirecell.log

--- a/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_overlay_WCP_00_17_00.sh
+++ b/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_overlay_WCP_00_17_00.sh
@@ -11,7 +11,7 @@ echo $UBOONECODE_VERSION | tee -a wirecell.log
 echo $WCP_VERSION | tee -a wirecell.log
 date | tee -a wirecell.log
 
-wc_input_celltree=`ls celltreeDATA*.root | xargs | awk '{print $1}'`
+wc_input_celltree=`ls celltreeOVERLAY*.root | xargs | awk '{print $1}'`
 if [ ! -e "$wc_input_celltree" ]; then
 	echo "Celltree root not found!" | tee -a wirecell.log
 	exit 201
@@ -20,7 +20,7 @@ fi
 echo "contents in this directory: " | tee -a wirecell.log
 ls -t | tee -a wirecell.log
 
-wc_eventcount=`grep event_count celltreeDATA*.json | awk '{print substr($2, 1, length($2)-1)}'`
+wc_eventcount=`grep event_count celltreeOVERLAY*.json | awk '{print substr($2, 1, length($2)-1)}'`
 echo "celltree input: $wc_input_celltree, number of events: $wc_eventcount" | tee -a wirecell.log
 
 echo "now working in $wc_workdir" | tee -a wirecell.log
@@ -30,7 +30,9 @@ cp $wc_input_celltree WCPwork/
 
 echo "set up additional environment for wirecell" | tee -a wirecell.log
 cd WCPwork 
-
+#setup numpy v1_14_3 -q e17:openblas:p2714b:prof
+#setup libtorch v1_0_1 -q e17:prof
+#setup SparseConvNet 8422a6f -q e17:prof
 setup SparseConvNet v01_00_00
 export PYTHONPATH=$WCP_FQ_DIR/python:$PYTHONPATH #may not needed any longer; already appened in uboonecode
 
@@ -47,13 +49,17 @@ touch WCP_analysis.log
 for ((n=0; n<$(($wc_eventcount)); n++))
 do
 	echo "event $n processing starts." | tee -a ../wirecell.log
-	wire-cell-imaging-lmem-celltree ./input_data_files/ChannelWireGeometry_v2.txt $wc_input_celltree $n -d0 -a1 -s2 2>&1 | tee -a ../wirecell.log
+	wire-cell-imaging-lmem-celltree ./input_data_files/ChannelWireGeometry_v2.txt $wc_input_celltree $n -d1 -s2 2>&1 | tee -a ../wirecell.log
 	echo "event $n imaging finished." | tee -a ../wirecell.log
 	###empty images
 	numgoodcell=`tail -n 10 ../wirecell.log | grep "mcell" | awk '{print $5}'`
 	echo "Number of good cells: $numgoodcell" | tee -a ../wirecell.log 
 	if [ x$numgoodcell != x -a "$numgoodcell" = "0" ]; then
       		echo "WARNING: empty 3D image!" | tee -a ../wirecell.log
+		touch nuseldummy_imaging${n}.root
+		touch portdummy_imaging${n}.root
+		rm result_*.root
+		continue	
 	fi
 
 	echo "event $n matching starts."
@@ -65,7 +71,10 @@ do
 		input2=${input1#*result_}
 		echo $input2 | tee -a ../wirecell.log
 		mv $imagingfile imaging_$input2.root
-		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -y1 -d0 2>&1 | tee -a ../wirecell.log
+		#prod-nusel-eval ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -d0 -p1 2>&1 | tee -a ../wirecell.log
+		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -d1 2>&1 | tee -a ../wirecell.log
+		#mv nuselEval*.root nusel_$input2.root
+		#mv port*.root porting_$input2.root
 		warning=`tail -n 1 ../wirecell.log`
 		echo "$warning"
 		if [ "$warning" = "No points! Quit! " ]; then
@@ -73,11 +82,6 @@ do
 			touch nuseldummy_${input2}.root
 			touch portdummy_${input2}.root
 		fi
-                image_fail=`grep "image_fail for ${input2}" ../wirecell.log | awk '{print $1}'`
-                if [ x$image_fail != x -a "$image_fail" = "1" ]; then
-                        mv nuselEval_${input2}.root nuselEvalImageFail_${input2}.root
-                        mv port_${input2}.root portImageFail_${input2}.root
-                fi
 	done
 	echo "event $n matching finished."
 done
@@ -86,21 +90,11 @@ echo "Merge output" | tee -a ../wirecell.log
 echo "contents in this directory: " | tee -a ../wirecell.log
 ls -t | tee -a ../wirecell.log
 hadd merge.root ./port_*.root
-hadd nuselDATA_WCP.root ./nuselEval_*.root
-#hadd the files without image failures seperatly to make sure the tree structure is good
-for file in nuselEvalImageFail*; do
-    if [[ -f $file ]]; then
-        mv merge.root merge_temp.root
-        mv nuselDATA_WCP.root nuselDATA_WCP_temp.root
-        hadd merge.root merge_temp.root portImageFail*
-        hadd nuselDATA_WCP.root nuselDATA_WCP_temp.root nuselEvalImageFail*
-        break
-    fi
-done
+hadd nuselOVERLAY_WCP.root ./nuselEval_*.root
 
 # stage2 (reco2) starts here
 echo "wirecell stage2 starts here"
-wc_input_celltree="nuselDATA_WCP.root"
+wc_input_celltree="nuselOVERLAY_WCP.root"
 ###
 # The number of entries of the input file could be
 # less than the total number of events in the artroot 
@@ -132,7 +126,6 @@ do
 		mv $stmfile STM_$stminput2.root
 		### only if in-time match found
 		test_stm STM_$stminput2.root 1>>WCP_STM.log 2>STMerror.log
-                test_stm_kdar STM_$stminput2.root 1>>WCP_STM_KDAR.log 2>STMerror.log
 		cat STMerror.log | tee -a ../wirecell.log 
 	done
 	echo "event $n cosmic rejection finished." | tee -a ../wirecell.log
@@ -154,6 +147,9 @@ do
         echo "WCP cosmic tagger: $wcreco2_runinfo $wcreco2_tag1 $wcreco2_tag2 $wcreco2_tag3 $wcreco2_tag4 $wcreco2_tag5 $wcreco2_tag6 $wcreco2_tag7" | tee -a WCP_analysis.log 
 	if [ -n "$wcreco2_runinfo" ]; then 
         if [ $wcreco2_tag1 != 0 -a $wcreco2_tag2 = 0 -a $wcreco2_tag3 = 0 -a $wcreco2_tag4 = 0 -a $wcreco2_tag5 = 0 -a $wcreco2_tag6 = 0 -a $(echo "$wcreco2_tag7 > 0"|bc) = 1 ]; then
+                #run=`echo $runinfo | awk -F "_" '{print $1}'`
+                #subrun=`echo $runinfo | awk -F "_" '{print $2}'`
+                #event=`echo $runinfo | awk -F "_" '{print $3}'`
 
 		echo "event $n nue starts." | tee -a WCP_analysis.log	
 		wire-cell-prod-nue ./input_data_files/ChannelWireGeometry_v2.txt $wc_input_celltree $n -d0 2>&1 | tee -a WCP_analysis.log
@@ -184,21 +180,28 @@ echo "contents in this directory: " | tee -a ../wirecell.log
 ls -t | tee -a ../wirecell.log
 
 echo "Check the number of root files" | tee -a ../wirecell.log
-wc_nevts1=`ls nusel*root | grep -E "Eval|dummy" | wc -l` # ignore nuselDATA_WCP.root
+wc_nevts1=`ls nusel*root | grep -E "Eval|dummy" | wc -l` # ignore nuselOVERLAY_WCP.root
 wc_nevts2=`ls port*.root | wc -l`
 wc_nevts3=`ls STM*.root | wc -l`
 if [ $wc_nevts1 = $wc_nevts2 -a $wc_nevts1 = $wc_nevts3 -a $wc_nevts1 = $wc_eventcount ]; then
 	echo "Good!" | tee -a ../wirecell.log
 else
 	echo "Bad: nusel $wc_nevts1, port $wc_nevts2, stm $wc_nevts3, input $wc_eventcount" | tee -a ../wirecell.log
+ 	##touch merge.root ### empty merge.root --> WCP failure	
 	exit 204
 fi
 
+
 mv WCP_STM.log $wc_workdir
-mv WCP_STM_KDAR.log $wc_workdir
 mv WCP_analysis.log $wc_workdir
+# mv imaging*.root $wc_workdir
+# mv nuselDATA_WCP.root $wc_workdir
+# mv merge.root $wc_workdir # to not confuse production system
+                            # keep it in WCPwork, see run_slimmed_port_data.fcl
+# mv nue_*.root $wc_workdir # run_wcpf_port.fcl
+
 cd $wc_workdir
-rm celltreeDATA*.root
+rm celltreeOVERLAY*.root
 echo "Done! Done! Done!" | tee -a wirecell.log
 date | tee -a wirecell.log
 

--- a/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_overlay_numi.sh
+++ b/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_overlay_numi.sh
@@ -30,9 +30,7 @@ cp $wc_input_celltree WCPwork/
 
 echo "set up additional environment for wirecell" | tee -a wirecell.log
 cd WCPwork 
-#setup numpy v1_14_3 -q e17:openblas:p2714b:prof
-#setup libtorch v1_0_1 -q e17:prof
-#setup SparseConvNet 8422a6f -q e17:prof
+
 setup SparseConvNet v01_00_00
 export PYTHONPATH=$WCP_FQ_DIR/python:$PYTHONPATH #may not needed any longer; already appened in uboonecode
 
@@ -56,10 +54,6 @@ do
 	echo "Number of good cells: $numgoodcell" | tee -a ../wirecell.log 
 	if [ x$numgoodcell != x -a "$numgoodcell" = "0" ]; then
       		echo "WARNING: empty 3D image!" | tee -a ../wirecell.log
-		touch nuseldummy_imaging${n}.root
-		touch portdummy_imaging${n}.root
-		rm result_*.root
-		continue	
 	fi
 
 	echo "event $n matching starts."
@@ -71,10 +65,7 @@ do
 		input2=${input1#*result_}
 		echo $input2 | tee -a ../wirecell.log
 		mv $imagingfile imaging_$input2.root
-		#prod-nusel-eval ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -d0 -p1 2>&1 | tee -a ../wirecell.log
-		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -d1 2>&1 | tee -a ../wirecell.log
-		#mv nuselEval*.root nusel_$input2.root
-		#mv port*.root porting_$input2.root
+		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -y1 -d1 2>&1 | tee -a ../wirecell.log
 		warning=`tail -n 1 ../wirecell.log`
 		echo "$warning"
 		if [ "$warning" = "No points! Quit! " ]; then
@@ -82,6 +73,11 @@ do
 			touch nuseldummy_${input2}.root
 			touch portdummy_${input2}.root
 		fi
+                image_fail=`grep "image_fail for ${input2}" ../wirecell.log | awk '{print $1}'`
+                if [ x$image_fail != x -a "$image_fail" = "1" ]; then
+                        mv nuselEval_${input2}.root nuselEvalImageFail_${input2}.root
+                        mv port_${input2}.root portImageFail_${input2}.root
+                fi
 	done
 	echo "event $n matching finished."
 done
@@ -91,6 +87,16 @@ echo "contents in this directory: " | tee -a ../wirecell.log
 ls -t | tee -a ../wirecell.log
 hadd merge.root ./port_*.root
 hadd nuselOVERLAY_WCP.root ./nuselEval_*.root
+#hadd the files without image failures seperatly to make sure the tree structure is good
+for file in nuselEvalImageFail*; do
+    if [[ -f $file ]]; then
+        mv merge.root merge_temp.root
+        mv nuselOVERLAY_WCP.root nuselOVERLAY_WCP_temp.root
+        hadd merge.root merge_temp.root portImageFail*
+        hadd nuselOVERLAY_WCP.root nuselOVERLAY_WCP_temp.root nuselEvalImageFail*
+        break
+    fi
+done
 
 # stage2 (reco2) starts here
 echo "wirecell stage2 starts here"
@@ -126,6 +132,7 @@ do
 		mv $stmfile STM_$stminput2.root
 		### only if in-time match found
 		test_stm STM_$stminput2.root 1>>WCP_STM.log 2>STMerror.log
+                test_stm_kdar STM_$stminput2.root 1>>WCP_STM_KDAR.log 2>STMerror.log
 		cat STMerror.log | tee -a ../wirecell.log 
 	done
 	echo "event $n cosmic rejection finished." | tee -a ../wirecell.log
@@ -147,9 +154,6 @@ do
         echo "WCP cosmic tagger: $wcreco2_runinfo $wcreco2_tag1 $wcreco2_tag2 $wcreco2_tag3 $wcreco2_tag4 $wcreco2_tag5 $wcreco2_tag6 $wcreco2_tag7" | tee -a WCP_analysis.log 
 	if [ -n "$wcreco2_runinfo" ]; then 
         if [ $wcreco2_tag1 != 0 -a $wcreco2_tag2 = 0 -a $wcreco2_tag3 = 0 -a $wcreco2_tag4 = 0 -a $wcreco2_tag5 = 0 -a $wcreco2_tag6 = 0 -a $(echo "$wcreco2_tag7 > 0"|bc) = 1 ]; then
-                #run=`echo $runinfo | awk -F "_" '{print $1}'`
-                #subrun=`echo $runinfo | awk -F "_" '{print $2}'`
-                #event=`echo $runinfo | awk -F "_" '{print $3}'`
 
 		echo "event $n nue starts." | tee -a WCP_analysis.log	
 		wire-cell-prod-nue ./input_data_files/ChannelWireGeometry_v2.txt $wc_input_celltree $n -d0 2>&1 | tee -a WCP_analysis.log
@@ -187,19 +191,12 @@ if [ $wc_nevts1 = $wc_nevts2 -a $wc_nevts1 = $wc_nevts3 -a $wc_nevts1 = $wc_even
 	echo "Good!" | tee -a ../wirecell.log
 else
 	echo "Bad: nusel $wc_nevts1, port $wc_nevts2, stm $wc_nevts3, input $wc_eventcount" | tee -a ../wirecell.log
- 	##touch merge.root ### empty merge.root --> WCP failure	
 	exit 204
 fi
 
-
 mv WCP_STM.log $wc_workdir
+mv WCP_STM_KDAR.log $wc_workdir
 mv WCP_analysis.log $wc_workdir
-# mv imaging*.root $wc_workdir
-# mv nuselDATA_WCP.root $wc_workdir
-# mv merge.root $wc_workdir # to not confuse production system
-                            # keep it in WCPwork, see run_slimmed_port_data.fcl
-# mv nue_*.root $wc_workdir # run_wcpf_port.fcl
-
 cd $wc_workdir
 rm celltreeOVERLAY*.root
 echo "Done! Done! Done!" | tee -a wirecell.log

--- a/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_overlay_numi_WCP_00_17_00.sh
+++ b/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_overlay_numi_WCP_00_17_00.sh
@@ -11,7 +11,7 @@ echo $UBOONECODE_VERSION | tee -a wirecell.log
 echo $WCP_VERSION | tee -a wirecell.log
 date | tee -a wirecell.log
 
-wc_input_celltree=`ls celltreeDATA*.root | xargs | awk '{print $1}'`
+wc_input_celltree=`ls celltreeOVERLAY*.root | xargs | awk '{print $1}'`
 if [ ! -e "$wc_input_celltree" ]; then
 	echo "Celltree root not found!" | tee -a wirecell.log
 	exit 201
@@ -20,7 +20,7 @@ fi
 echo "contents in this directory: " | tee -a wirecell.log
 ls -t | tee -a wirecell.log
 
-wc_eventcount=`grep event_count celltreeDATA*.json | awk '{print substr($2, 1, length($2)-1)}'`
+wc_eventcount=`grep event_count celltreeOVERLAY*.json | awk '{print substr($2, 1, length($2)-1)}'`
 echo "celltree input: $wc_input_celltree, number of events: $wc_eventcount" | tee -a wirecell.log
 
 echo "now working in $wc_workdir" | tee -a wirecell.log
@@ -30,7 +30,9 @@ cp $wc_input_celltree WCPwork/
 
 echo "set up additional environment for wirecell" | tee -a wirecell.log
 cd WCPwork 
-
+#setup numpy v1_14_3 -q e17:openblas:p2714b:prof
+#setup libtorch v1_0_1 -q e17:prof
+#setup SparseConvNet 8422a6f -q e17:prof
 setup SparseConvNet v01_00_00
 export PYTHONPATH=$WCP_FQ_DIR/python:$PYTHONPATH #may not needed any longer; already appened in uboonecode
 
@@ -47,13 +49,17 @@ touch WCP_analysis.log
 for ((n=0; n<$(($wc_eventcount)); n++))
 do
 	echo "event $n processing starts." | tee -a ../wirecell.log
-	wire-cell-imaging-lmem-celltree ./input_data_files/ChannelWireGeometry_v2.txt $wc_input_celltree $n -d0 -a1 -s2 2>&1 | tee -a ../wirecell.log
+	wire-cell-imaging-lmem-celltree ./input_data_files/ChannelWireGeometry_v2.txt $wc_input_celltree $n -d1 -a1 -s2 2>&1 | tee -a ../wirecell.log
 	echo "event $n imaging finished." | tee -a ../wirecell.log
 	###empty images
 	numgoodcell=`tail -n 10 ../wirecell.log | grep "mcell" | awk '{print $5}'`
 	echo "Number of good cells: $numgoodcell" | tee -a ../wirecell.log 
 	if [ x$numgoodcell != x -a "$numgoodcell" = "0" ]; then
       		echo "WARNING: empty 3D image!" | tee -a ../wirecell.log
+		touch nuseldummy_imaging${n}.root
+		touch portdummy_imaging${n}.root
+		rm result_*.root
+		continue	
 	fi
 
 	echo "event $n matching starts."
@@ -65,7 +71,10 @@ do
 		input2=${input1#*result_}
 		echo $input2 | tee -a ../wirecell.log
 		mv $imagingfile imaging_$input2.root
-		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -y1 -d0 2>&1 | tee -a ../wirecell.log
+		#prod-nusel-eval ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -d0 -p1 2>&1 | tee -a ../wirecell.log
+		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -d1 2>&1 | tee -a ../wirecell.log
+		#mv nuselEval*.root nusel_$input2.root
+		#mv port*.root porting_$input2.root
 		warning=`tail -n 1 ../wirecell.log`
 		echo "$warning"
 		if [ "$warning" = "No points! Quit! " ]; then
@@ -73,11 +82,6 @@ do
 			touch nuseldummy_${input2}.root
 			touch portdummy_${input2}.root
 		fi
-                image_fail=`grep "image_fail for ${input2}" ../wirecell.log | awk '{print $1}'`
-                if [ x$image_fail != x -a "$image_fail" = "1" ]; then
-                        mv nuselEval_${input2}.root nuselEvalImageFail_${input2}.root
-                        mv port_${input2}.root portImageFail_${input2}.root
-                fi
 	done
 	echo "event $n matching finished."
 done
@@ -86,21 +90,11 @@ echo "Merge output" | tee -a ../wirecell.log
 echo "contents in this directory: " | tee -a ../wirecell.log
 ls -t | tee -a ../wirecell.log
 hadd merge.root ./port_*.root
-hadd nuselDATA_WCP.root ./nuselEval_*.root
-#hadd the files without image failures seperatly to make sure the tree structure is good
-for file in nuselEvalImageFail*; do
-    if [[ -f $file ]]; then
-        mv merge.root merge_temp.root
-        mv nuselDATA_WCP.root nuselDATA_WCP_temp.root
-        hadd merge.root merge_temp.root portImageFail*
-        hadd nuselDATA_WCP.root nuselDATA_WCP_temp.root nuselEvalImageFail*
-        break
-    fi
-done
+hadd nuselOVERLAY_WCP.root ./nuselEval_*.root
 
 # stage2 (reco2) starts here
 echo "wirecell stage2 starts here"
-wc_input_celltree="nuselDATA_WCP.root"
+wc_input_celltree="nuselOVERLAY_WCP.root"
 ###
 # The number of entries of the input file could be
 # less than the total number of events in the artroot 
@@ -132,7 +126,6 @@ do
 		mv $stmfile STM_$stminput2.root
 		### only if in-time match found
 		test_stm STM_$stminput2.root 1>>WCP_STM.log 2>STMerror.log
-                test_stm_kdar STM_$stminput2.root 1>>WCP_STM_KDAR.log 2>STMerror.log
 		cat STMerror.log | tee -a ../wirecell.log 
 	done
 	echo "event $n cosmic rejection finished." | tee -a ../wirecell.log
@@ -154,6 +147,9 @@ do
         echo "WCP cosmic tagger: $wcreco2_runinfo $wcreco2_tag1 $wcreco2_tag2 $wcreco2_tag3 $wcreco2_tag4 $wcreco2_tag5 $wcreco2_tag6 $wcreco2_tag7" | tee -a WCP_analysis.log 
 	if [ -n "$wcreco2_runinfo" ]; then 
         if [ $wcreco2_tag1 != 0 -a $wcreco2_tag2 = 0 -a $wcreco2_tag3 = 0 -a $wcreco2_tag4 = 0 -a $wcreco2_tag5 = 0 -a $wcreco2_tag6 = 0 -a $(echo "$wcreco2_tag7 > 0"|bc) = 1 ]; then
+                #run=`echo $runinfo | awk -F "_" '{print $1}'`
+                #subrun=`echo $runinfo | awk -F "_" '{print $2}'`
+                #event=`echo $runinfo | awk -F "_" '{print $3}'`
 
 		echo "event $n nue starts." | tee -a WCP_analysis.log	
 		wire-cell-prod-nue ./input_data_files/ChannelWireGeometry_v2.txt $wc_input_celltree $n -d0 2>&1 | tee -a WCP_analysis.log
@@ -184,21 +180,28 @@ echo "contents in this directory: " | tee -a ../wirecell.log
 ls -t | tee -a ../wirecell.log
 
 echo "Check the number of root files" | tee -a ../wirecell.log
-wc_nevts1=`ls nusel*root | grep -E "Eval|dummy" | wc -l` # ignore nuselDATA_WCP.root
+wc_nevts1=`ls nusel*root | grep -E "Eval|dummy" | wc -l` # ignore nuselOVERLAY_WCP.root
 wc_nevts2=`ls port*.root | wc -l`
 wc_nevts3=`ls STM*.root | wc -l`
 if [ $wc_nevts1 = $wc_nevts2 -a $wc_nevts1 = $wc_nevts3 -a $wc_nevts1 = $wc_eventcount ]; then
 	echo "Good!" | tee -a ../wirecell.log
 else
 	echo "Bad: nusel $wc_nevts1, port $wc_nevts2, stm $wc_nevts3, input $wc_eventcount" | tee -a ../wirecell.log
+ 	##touch merge.root ### empty merge.root --> WCP failure	
 	exit 204
 fi
 
+
 mv WCP_STM.log $wc_workdir
-mv WCP_STM_KDAR.log $wc_workdir
 mv WCP_analysis.log $wc_workdir
+# mv imaging*.root $wc_workdir
+# mv nuselDATA_WCP.root $wc_workdir
+# mv merge.root $wc_workdir # to not confuse production system
+                            # keep it in WCPwork, see run_slimmed_port_data.fcl
+# mv nue_*.root $wc_workdir # run_wcpf_port.fcl
+
 cd $wc_workdir
-rm celltreeDATA*.root
+rm celltreeOVERLAY*.root
 echo "Done! Done! Done!" | tee -a wirecell.log
 date | tee -a wirecell.log
 

--- a/ubana/MicroBooNEWireCell/utils/update_wcpf_port_numi.sh
+++ b/ubana/MicroBooNEWireCell/utils/update_wcpf_port_numi.sh
@@ -1,0 +1,50 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters.
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL wrapper_update_wcpf_port.fcl
+
+# Generate wrapper.
+
+cat <<EOF > $FCL
+#include "wrapper_update_wcpf_port.fcl"
+
+physics.producers.wirecellPF.ssmBDT:                      true
+physics.producers.wirecellPF.PFInput_prefix:              "WCPwork/nue"
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi


### PR DESCRIPTION
Updates to the WC ntuple maker to save both the KDAR generic neutrino selection and the regular generic neutrino selection. Several additional variables were also added to the KDAR tagger. ntuple maker also has a small patch to the ns timing to improve performance on saturated PMTs in NuMI data. WC reco2 helper scripts were also updated. The old scripts which do not have patches to the workflow to do the KDAR generic selection and don't contain protection again failure on individual events are labeled as *_00_10_00.sh