### PR TITLE
Update WC reco2 production helper scripts.

### DIFF
--- a/ubana/MicroBooNEWireCell/WireCellAnaTree_module.cc
+++ b/ubana/MicroBooNEWireCell/WireCellAnaTree_module.cc
@@ -7196,7 +7196,7 @@ void WireCellAnaTree::nsbeamtiming(art::Event const& e)
   for (int i=0; i<32; i++){
     calib[i] = gain_provider.ExtraInfo(i).GetFloatData("amplitude_gain");
   }
-  if(!fMC) {BeamT0 = getBeamWF(e);}
+  if(!fMC && fFileType.find("ext")==std::string::npos) {BeamT0 = getBeamWF(e);}
   else{BeamT0 = 0;}//no RWM signal simulated for now, so just set this to 0
   Float_t x =        f_reco_nuvtxX;
   Float_t y =        f_reco_nuvtxY;

--- a/ubana/MicroBooNEWireCell/job/run_wcanatree.fcl
+++ b/ubana/MicroBooNEWireCell/job/run_wcanatree.fcl
@@ -62,6 +62,10 @@ physics:
       PFDump_min_truth_energy:  0.010 # GeV
 
       # nanosecond beam timing
+      SaveSPS:              true
+      SavePMT:              true
+      ns_time_usePID:       true
+
       ShiftOffset: 0 #0 for Run 1, 387.8 for Run 3 before RWM cable change and 118.3 Run 3 after RWM cable change and Run 4
       isRun3: false #is this run 3 (where the RWM cable changed)?
       # various fit parameters for corrections

--- a/ubana/MicroBooNEWireCell/job/run_wcanatree_overlay.fcl
+++ b/ubana/MicroBooNEWireCell/job/run_wcanatree_overlay.fcl
@@ -7,4 +7,15 @@ physics.analyzers.wcpselection.POT_inputTag:	"generator"
 physics.analyzers.wcpweights.SaveWeights:	true
 physics.analyzers.wcpweights.SaveFullWeights:	true
 
+physics.analyzers.wcpselection.ccnd1_a: 0 
+physics.analyzers.wcpselection.ccnd1_b: 0
+physics.analyzers.wcpselection.ccnd2_a: 0 
+physics.analyzers.wcpselection.ccnd2_b: 0 
+physics.analyzers.wcpselection.ccnd3_a: 0
+physics.analyzers.wcpselection.ccnd3_b: 0
+physics.analyzers.wcpselection.ccnd3_c: 0
+physics.analyzers.wcpselection.ccnd3_d: 0
+physics.analyzers.wcpselection.ccnd4_a: 0 
+physics.analyzers.wcpselection.ccnd4_b: 0
+
 physics.ana: [wcpselection, wcpweights]

--- a/ubana/MicroBooNEWireCell/job/run_wcanatree_overlay_numi_oldflux_rw.fcl
+++ b/ubana/MicroBooNEWireCell/job/run_wcanatree_overlay_numi_oldflux_rw.fcl
@@ -58,3 +58,15 @@ physics.analyzers.wcpweights.GenieKnobs:        [ "All_UBGenie"
                                                 , "splines_general_Spline"
                                                 , "xsr_scc_Fa3_SCC"
                                                 , "xsr_scc_Fv3_SCC" ]
+
+physics.analyzers.wcpselection.ccnd1_a: 0
+physics.analyzers.wcpselection.ccnd1_b: 0
+physics.analyzers.wcpselection.ccnd2_a: 0
+physics.analyzers.wcpselection.ccnd2_b: 0
+physics.analyzers.wcpselection.ccnd3_a: 0
+physics.analyzers.wcpselection.ccnd3_b: 0
+physics.analyzers.wcpselection.ccnd3_c: 0
+physics.analyzers.wcpselection.ccnd3_d: 0
+physics.analyzers.wcpselection.ccnd4_a: 0
+physics.analyzers.wcpselection.ccnd4_b: 0
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype.sh
@@ -1,0 +1,162 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+ccnd1_a="0.529594"
+ccnd1_b="7.13804"
+ccnd2_a="0.068752"
+ccnd2_b="2.32023"
+ccnd3_a="0.4697"
+ccnd3_b="0.004233"
+ccnd3_c="0.000001006"
+ccnd3_d="-0.195"
+ccnd4_a="0"
+ccnd4_b="0"
+
+flag_numi="false"
+beam="bnb"
+if ls Physics*numi*.root 1> /dev/null 2>&1 || ls Beam*numi*.root 1> /dev/null 2>&1 ; then
+	flag_numi="true"
+        beam="numi"
+        flag_numi="true"
+        ccnd1_a="0.4343"
+        ccnd1_b="6.2884"
+        ccnd2_a="0.0637"
+        ccnd2_b="1.489"
+        ccnd3_a="0"
+        ccnd3_b="0"
+        ccnd3_c="0"
+        ccnd3_d="0"
+        ccnd4_a="0.0125"
+        ccnd4_b="2.3152"
+fi
+
+flag_ext="data"
+if ls Physics*ext*.root 1> /dev/null 2>&1 || ls Beam*ext*.root 1> /dev/null 2>&1 ; then
+	flag_ext="ext"
+fi
+
+
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.ccnd1_a: ${ccnd1_a} 
+physics.analyzers.wcpselection.ccnd1_b: ${ccnd1_b}
+physics.analyzers.wcpselection.ccnd2_a: ${ccnd2_a} 
+physics.analyzers.wcpselection.ccnd2_b: ${ccnd2_b} 
+physics.analyzers.wcpselection.ccnd3_a: ${ccnd3_a}
+physics.analyzers.wcpselection.ccnd3_b: ${ccnd3_b}
+physics.analyzers.wcpselection.ccnd3_c: ${ccnd3_c}
+physics.analyzers.wcpselection.ccnd3_d: ${ccnd3_d}
+physics.analyzers.wcpselection.ccnd4_a: ${ccnd4_a} 
+physics.analyzers.wcpselection.ccnd4_b: ${ccnd4_b} 
+
+physics.analyzers.wcpselection.FileType: "${flag_ext}_${beam}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "${flag_ext}_${beam}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype.sh
@@ -44,7 +44,8 @@ run_number=`echo $next_stage_input | cut -d '-' -f3`
 echo $run_number
 
 FT_STREAM="run1"
-
+isRun3="false"
+ShiftOffset="0"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
@@ -61,30 +62,39 @@ elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    #
 then
         echo "run run3a fhicl"
         FT_STREAM="run3"
+	isRun3="true"
+        ShiftOffset="387.8"
 elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
 then
         echo "run run3b fhicl"
         FT_STREAM="run3"
+	isRun3="true"
+        ShiftOffset="387.8"
 elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
 then
         echo "run run4a fhicl"
         FT_STREAM="run4a"
+	ShiftOffset="118.3"
 elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
 then
         echo "run run4b fhicl"
         FT_STREAM="run4b"
+	ShiftOffset="118.3"
 elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
 then
         echo "run run4c fhicl"
         FT_STREAM="run4c"
+	ShiftOffset="118.3"
 elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
 then
         echo "run run4d fhicl"
         FT_STREAM="run4d"
+	ShiftOffset="118.3"
 elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
 then
         echo "run run5 fhicl"
         FT_STREAM="run5"
+	ShiftOffset="118.3"
 fi
 
 ccnd1_a="0.529594"
@@ -114,13 +124,14 @@ if ls Physics*numi*.root 1> /dev/null 2>&1 || ls Beam*numi*.root 1> /dev/null 2>
         ccnd3_d="0"
         ccnd4_a="0.0125"
         ccnd4_b="2.3152"
+        isRun3="false"
+        ShiftOffset="0"
 fi
 
 flag_ext="data"
 if ls Physics*ext*.root 1> /dev/null 2>&1 || ls Beam*ext*.root 1> /dev/null 2>&1 ; then
 	flag_ext="ext"
 fi
-
 
 
 cat <<EOF > $FCL
@@ -138,6 +149,9 @@ physics.analyzers.wcpselection.ccnd3_c: ${ccnd3_c}
 physics.analyzers.wcpselection.ccnd3_d: ${ccnd3_d}
 physics.analyzers.wcpselection.ccnd4_a: ${ccnd4_a} 
 physics.analyzers.wcpselection.ccnd4_b: ${ccnd4_b} 
+
+physics.analyzers.wcpselection.ShiftOffset: ${ShiftOffset}
+physics.analyzers.wcpselection.isRun3: ${isRun3}
 
 physics.analyzers.wcpselection.FileType: "${flag_ext}_${beam}_${FT_STREAM}"
 physics.analyzers.wcpweights.FileType: "${flag_ext}_${beam}_${FT_STREAM}"

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ccpi0_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ccpi0_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="ccpi0_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="false"
+beam="bnb"
+horncur=''
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ccpi0_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ccpi0_overlay_detvar.sh
@@ -1,0 +1,159 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+
+
+sample_type='ccpi0_overlay'
+flag_SaveLeeWeights="false"
+flag_numi="false"
+flag_redk2nu="false"
+beam="bnb"
+horncur=""
+
+
+
+detvar_type="cv"
+if ls *reg4_SCE*.fcl 1> /dev/null 2>&1; then
+	detvar_type="SCE"
+elif ls *reg4_recombination*.fcl 1> /dev/null 2>&1; then
+        detvar_type="recombination"
+elif ls *wiremod_ScaleX*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMX"
+elif ls *wiremod_ScaleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMYZ"
+elif ls *wiremod_ScaleAngleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaYZ"
+elif ls *wiremod_ScaleAngleXZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaXZ"
+elif ls *reg4_LY_reyliegh*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_reyliegh"
+elif ls *reg4_LY_suppression75*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_down"
+elif ls *reg4_LY_attenuation8m*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_attenuation"
+else
+	echo "WARNING: Unable to establish DetVar type."
+        echo "Setting this to tbe the CV sample."
+        echo "Please check fhicls to ensure this is correct."
+fi
+
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_redk2nu}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_dirt_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_dirt_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="dirt_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="false"
+beam="bnb"
+horncur=''
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_fullosc_numu2nue_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_fullosc_numu2nue_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="fullosc_numu2nue_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="false"
+beam="bnb"
+horncur=''
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_intrinsic_nue_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_intrinsic_nue_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="intrinsic_nue"
+flag_SaveLeeWeights="true"
+flag_numi="false"
+beam="bnb"
+horncur=''
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_intrinsic_nue_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_intrinsic_nue_overlay_detvar.sh
@@ -1,0 +1,159 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+
+
+sample_type='intrinsic_nue'
+flag_SaveLeeWeights="true"
+flag_numi="false"
+flag_redk2nu="false"
+beam="bnb"
+horncur=""
+
+
+
+detvar_type="cv"
+if ls *reg4_SCE*.fcl 1> /dev/null 2>&1; then
+	detvar_type="SCE"
+elif ls *reg4_recombination*.fcl 1> /dev/null 2>&1; then
+        detvar_type="recombination"
+elif ls *wiremod_ScaleX*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMX"
+elif ls *wiremod_ScaleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMYZ"
+elif ls *wiremod_ScaleAngleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaYZ"
+elif ls *wiremod_ScaleAngleXZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaXZ"
+elif ls *reg4_LY_reyliegh*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_reyliegh"
+elif ls *reg4_LY_suppression75*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_down"
+elif ls *reg4_LY_attenuation8m*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_attenuation"
+else
+	echo "WARNING: Unable to establish DetVar type."
+        echo "Setting this to tbe the CV sample."
+        echo "Please check fhicls to ensure this is correct."
+fi
+
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_redk2nu}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncdelta_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncdelta_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="ncdelta_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="false"
+beam="bnb"
+horncur=''
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncdelta_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncdelta_overlay_detvar.sh
@@ -1,0 +1,159 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+
+
+sample_type='ncdelta_overlay'
+flag_SaveLeeWeights="false"
+flag_numi="false"
+flag_redk2nu="false"
+beam="bnb"
+horncur=""
+
+
+
+detvar_type="cv"
+if ls *reg4_SCE*.fcl 1> /dev/null 2>&1; then
+	detvar_type="SCE"
+elif ls *reg4_recombination*.fcl 1> /dev/null 2>&1; then
+        detvar_type="recombination"
+elif ls *wiremod_ScaleX*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMX"
+elif ls *wiremod_ScaleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMYZ"
+elif ls *wiremod_ScaleAngleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaYZ"
+elif ls *wiremod_ScaleAngleXZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaXZ"
+elif ls *reg4_LY_reyliegh*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_reyliegh"
+elif ls *reg4_LY_suppression75*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_down"
+elif ls *reg4_LY_attenuation8m*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_attenuation"
+else
+	echo "WARNING: Unable to establish DetVar type."
+        echo "Setting this to tbe the CV sample."
+        echo "Please check fhicls to ensure this is correct."
+fi
+
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_redk2nu}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncpi0_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncpi0_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="ncpi0_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="false"
+beam="bnb"
+horncur=''
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncpi0_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncpi0_overlay_detvar.sh
@@ -1,0 +1,159 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+
+
+sample_type='ncpi0_overlay'
+flag_SaveLeeWeights="false"
+flag_numi="false"
+flag_redk2nu="false"
+beam="bnb"
+horncur=""
+
+
+
+detvar_type="cv"
+if ls *reg4_SCE*.fcl 1> /dev/null 2>&1; then
+	detvar_type="SCE"
+elif ls *reg4_recombination*.fcl 1> /dev/null 2>&1; then
+        detvar_type="recombination"
+elif ls *wiremod_ScaleX*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMX"
+elif ls *wiremod_ScaleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMYZ"
+elif ls *wiremod_ScaleAngleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaYZ"
+elif ls *wiremod_ScaleAngleXZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaXZ"
+elif ls *reg4_LY_reyliegh*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_reyliegh"
+elif ls *reg4_LY_suppression75*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_down"
+elif ls *reg4_LY_attenuation8m*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_attenuation"
+else
+	echo "WARNING: Unable to establish DetVar type."
+        echo "Setting this to tbe the CV sample."
+        echo "Please check fhicls to ensure this is correct."
+fi
+
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_redk2nu}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_nu_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_nu_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="nu_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="false"
+beam="bnb"
+horncur=''
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_nu_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_nu_overlay_detvar.sh
@@ -1,0 +1,159 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+
+
+sample_type='nu_overlay'
+flag_SaveLeeWeights="false"
+flag_numi="false"
+flag_redk2nu="false"
+beam="bnb"
+horncur=""
+
+
+
+detvar_type="cv"
+if ls *reg4_SCE*.fcl 1> /dev/null 2>&1; then
+	detvar_type="SCE"
+elif ls *reg4_recombination*.fcl 1> /dev/null 2>&1; then
+        detvar_type="recombination"
+elif ls *wiremod_ScaleX*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMX"
+elif ls *wiremod_ScaleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMYZ"
+elif ls *wiremod_ScaleAngleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaYZ"
+elif ls *wiremod_ScaleAngleXZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaXZ"
+elif ls *reg4_LY_reyliegh*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_reyliegh"
+elif ls *reg4_LY_suppression75*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_down"
+elif ls *reg4_LY_attenuation8m*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_attenuation"
+else
+	echo "WARNING: Unable to establish DetVar type."
+        echo "Setting this to tbe the CV sample."
+        echo "Please check fhicls to ensure this is correct."
+fi
+
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_redk2nu}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_nuwro_fakedata.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_nuwro_fakedata.sh
@@ -1,0 +1,136 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="nuwro_fakedata"
+flag_SaveLeeWeights="false"
+flag_numi="false"
+beam="bnb"
+horncur=''
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.MC:              true
+physics.analyzers.wcpselection.SaveWeights:     false
+physics.analyzers.wcpselection.POT_inputTag:    "generator"
+
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_single_photon_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_single_photon_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="single_photon_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="false"
+beam="bnb"
+horncur=''
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_single_photon_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_single_photon_overlay_detvar.sh
@@ -1,0 +1,159 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+
+
+sample_type='single_photon_overlay'
+flag_SaveLeeWeights="false"
+flag_numi="false"
+flag_redk2nu="false"
+beam="bnb"
+horncur=""
+
+
+
+detvar_type="cv"
+if ls *reg4_SCE*.fcl 1> /dev/null 2>&1; then
+	detvar_type="SCE"
+elif ls *reg4_recombination*.fcl 1> /dev/null 2>&1; then
+        detvar_type="recombination"
+elif ls *wiremod_ScaleX*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMX"
+elif ls *wiremod_ScaleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMYZ"
+elif ls *wiremod_ScaleAngleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaYZ"
+elif ls *wiremod_ScaleAngleXZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaXZ"
+elif ls *reg4_LY_reyliegh*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_reyliegh"
+elif ls *reg4_LY_suppression75*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_down"
+elif ls *reg4_LY_attenuation8m*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_attenuation"
+else
+	echo "WARNING: Unable to establish DetVar type."
+        echo "Setting this to tbe the CV sample."
+        echo "Please check fhicls to ensure this is correct."
+fi
+
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_redk2nu}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_ccpi0_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_ccpi0_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="ccpi0_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="true"
+beam="numi"
+horncur='_fhc'
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_ccpi0_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_ccpi0_overlay_detvar.sh
@@ -1,0 +1,160 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+
+
+sample_type='ncpi0_overlay'
+flag_SaveLeeWeights="false"
+flag_numi="true"
+flag_redk2nu="false"
+beam="numi"
+horncur="_fhc"
+
+
+
+detvar_type="cv"
+if ls *reg4_SCE*.fcl 1> /dev/null 2>&1; then
+	detvar_type="SCE"
+elif ls *reg4_recombination*.fcl 1> /dev/null 2>&1; then
+        detvar_type="recombination"
+elif ls *wiremod_ScaleX*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMX"
+elif ls *wiremod_ScaleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMYZ"
+elif ls *wiremod_ScaleAngleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaYZ"
+elif ls *wiremod_ScaleAngleXZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaXZ"
+elif ls *reg4_LY_reyliegh*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_reyliegh"
+elif ls *reg4_LY_suppression75*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_down"
+elif ls *reg4_LY_attenuation8m*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_attenuation"
+else
+	echo "WARNING: Unable to establish DetVar type."
+        echo "Setting this to tbe the CV sample."
+        echo "Please check fhicls to ensure this is correct."
+        flag_redk2nu="true"
+fi
+
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_redk2nu}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_dirt_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_dirt_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="dirt_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="true"
+beam="numi"
+horncur='_fhc'
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_fullosc_numu2nue_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_fullosc_numu2nue_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="fullosc_numu2nue_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="true"
+beam="numi"
+horncur='_fhc'
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_intrinsic_nue_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_intrinsic_nue_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="intrinsic_nue_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="true"
+beam="numi"
+horncur='_fhc'
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_intrinsic_nue_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_intrinsic_nue_overlay_detvar.sh
@@ -1,0 +1,160 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+
+
+sample_type='intrinsic_nue_overlay'
+flag_SaveLeeWeights="false"
+flag_numi="true"
+flag_redk2nu="false"
+beam="numi"
+horncur="_fhc"
+
+
+
+detvar_type="cv"
+if ls *reg4_SCE*.fcl 1> /dev/null 2>&1; then
+	detvar_type="SCE"
+elif ls *reg4_recombination*.fcl 1> /dev/null 2>&1; then
+        detvar_type="recombination"
+elif ls *wiremod_ScaleX*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMX"
+elif ls *wiremod_ScaleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMYZ"
+elif ls *wiremod_ScaleAngleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaYZ"
+elif ls *wiremod_ScaleAngleXZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaXZ"
+elif ls *reg4_LY_reyliegh*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_reyliegh"
+elif ls *reg4_LY_suppression75*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_down"
+elif ls *reg4_LY_attenuation8m*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_attenuation"
+else
+	echo "WARNING: Unable to establish DetVar type."
+        echo "Setting this to tbe the CV sample."
+        echo "Please check fhicls to ensure this is correct."
+        flag_redk2nu="true"
+fi
+
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_redk2nu}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_kdar_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_kdar_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="kdar_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="true"
+beam="numi"
+horncur='_fhc'
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_kdar_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_kdar_overlay_detvar.sh
@@ -1,0 +1,160 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+
+
+sample_type='kdar_overlay'
+flag_SaveLeeWeights="false"
+flag_numi="true"
+flag_redk2nu="false"
+beam="numi"
+horncur="_fhc"
+
+
+
+detvar_type="cv"
+if ls *reg4_SCE*.fcl 1> /dev/null 2>&1; then
+	detvar_type="SCE"
+elif ls *reg4_recombination*.fcl 1> /dev/null 2>&1; then
+        detvar_type="recombination"
+elif ls *wiremod_ScaleX*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMX"
+elif ls *wiremod_ScaleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMYZ"
+elif ls *wiremod_ScaleAngleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaYZ"
+elif ls *wiremod_ScaleAngleXZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaXZ"
+elif ls *reg4_LY_reyliegh*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_reyliegh"
+elif ls *reg4_LY_suppression75*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_down"
+elif ls *reg4_LY_attenuation8m*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_attenuation"
+else
+	echo "WARNING: Unable to establish DetVar type."
+        echo "Setting this to tbe the CV sample."
+        echo "Please check fhicls to ensure this is correct."
+        flag_redk2nu="true"
+fi
+
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_redk2nu}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_ncpi0_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_ncpi0_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="ncpi0_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="true"
+beam="numi"
+horncur='_fhc'
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_ncpi0_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_ncpi0_overlay_detvar.sh
@@ -1,0 +1,160 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+
+
+sample_type='ncpi0_overlay'
+flag_SaveLeeWeights="false"
+flag_numi="true"
+flag_redk2nu="false"
+beam="numi"
+horncur="_fhc"
+
+
+
+detvar_type="cv"
+if ls *reg4_SCE*.fcl 1> /dev/null 2>&1; then
+	detvar_type="SCE"
+elif ls *reg4_recombination*.fcl 1> /dev/null 2>&1; then
+        detvar_type="recombination"
+elif ls *wiremod_ScaleX*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMX"
+elif ls *wiremod_ScaleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMYZ"
+elif ls *wiremod_ScaleAngleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaYZ"
+elif ls *wiremod_ScaleAngleXZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaXZ"
+elif ls *reg4_LY_reyliegh*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_reyliegh"
+elif ls *reg4_LY_suppression75*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_down"
+elif ls *reg4_LY_attenuation8m*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_attenuation"
+else
+	echo "WARNING: Unable to establish DetVar type."
+        echo "Setting this to tbe the CV sample."
+        echo "Please check fhicls to ensure this is correct."
+        flag_redk2nu="true"
+fi
+
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_redk2nu}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_nu_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_nu_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="nu_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="true"
+beam="numi"
+horncur='_fhc'
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_nu_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_nu_overlay_detvar.sh
@@ -1,0 +1,160 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+
+
+sample_type='nu_overlay'
+flag_SaveLeeWeights="false"
+flag_numi="true"
+flag_redk2nu="false"
+beam="numi"
+horncur="_fhc"
+
+
+
+detvar_type="cv"
+if ls *reg4_SCE*.fcl 1> /dev/null 2>&1; then
+	detvar_type="SCE"
+elif ls *reg4_recombination*.fcl 1> /dev/null 2>&1; then
+        detvar_type="recombination"
+elif ls *wiremod_ScaleX*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMX"
+elif ls *wiremod_ScaleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMYZ"
+elif ls *wiremod_ScaleAngleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaYZ"
+elif ls *wiremod_ScaleAngleXZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaXZ"
+elif ls *reg4_LY_reyliegh*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_reyliegh"
+elif ls *reg4_LY_suppression75*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_down"
+elif ls *reg4_LY_attenuation8m*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_attenuation"
+else
+	echo "WARNING: Unable to establish DetVar type."
+        echo "Setting this to tbe the CV sample."
+        echo "Please check fhicls to ensure this is correct."
+        flag_redk2nu="true"
+fi
+
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_redk2nu}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_nuwro_fakedata.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_nuwro_fakedata.sh
@@ -1,0 +1,136 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="nuwro_fakedata"
+flag_SaveLeeWeights="false"
+flag_numi="true"
+beam="numi"
+horncur='_fhc'
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.MC:              true
+physics.analyzers.wcpselection.SaveWeights:     false
+physics.analyzers.wcpselection.POT_inputTag:    "generator"
+
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_ccpi0_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_ccpi0_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="ccpi0_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="true"
+beam="numi"
+horncur='_rhc'
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_ccpi0_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_ccpi0_overlay_detvar.sh
@@ -1,0 +1,160 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+
+
+sample_type='ncpi0_overlay'
+flag_SaveLeeWeights="false"
+flag_numi="true"
+flag_redk2nu="false"
+beam="numi"
+horncur="_rhc"
+
+
+
+detvar_type="cv"
+if ls *reg4_SCE*.fcl 1> /dev/null 2>&1; then
+	detvar_type="SCE"
+elif ls *reg4_recombination*.fcl 1> /dev/null 2>&1; then
+        detvar_type="recombination"
+elif ls *wiremod_ScaleX*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMX"
+elif ls *wiremod_ScaleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMYZ"
+elif ls *wiremod_ScaleAngleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaYZ"
+elif ls *wiremod_ScaleAngleXZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaXZ"
+elif ls *reg4_LY_reyliegh*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_reyliegh"
+elif ls *reg4_LY_suppression75*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_down"
+elif ls *reg4_LY_attenuation8m*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_attenuation"
+else
+	echo "WARNING: Unable to establish DetVar type."
+        echo "Setting this to tbe the CV sample."
+        echo "Please check fhicls to ensure this is correct."
+        flag_redk2nu="true"
+fi
+
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_redk2nu}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_dirt_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_dirt_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="dirt_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="true"
+beam="numi"
+horncur='_rhc'
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_fullosc_numu2nue_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_fullosc_numu2nue_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="fullosc_numu2nue_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="true"
+beam="numi"
+horncur='_rhc'
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_intrinsic_nue_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_intrinsic_nue_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="intrinsic_nue_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="true"
+beam="numi"
+horncur='_rhc'
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_intrinsic_nue_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_intrinsic_nue_overlay_detvar.sh
@@ -1,0 +1,160 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+
+
+sample_type='intrinsic_nue_overlay'
+flag_SaveLeeWeights="false"
+flag_numi="true"
+flag_redk2nu="false"
+beam="numi"
+horncur="_rhc"
+
+
+
+detvar_type="cv"
+if ls *reg4_SCE*.fcl 1> /dev/null 2>&1; then
+	detvar_type="SCE"
+elif ls *reg4_recombination*.fcl 1> /dev/null 2>&1; then
+        detvar_type="recombination"
+elif ls *wiremod_ScaleX*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMX"
+elif ls *wiremod_ScaleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMYZ"
+elif ls *wiremod_ScaleAngleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaYZ"
+elif ls *wiremod_ScaleAngleXZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaXZ"
+elif ls *reg4_LY_reyliegh*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_reyliegh"
+elif ls *reg4_LY_suppression75*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_down"
+elif ls *reg4_LY_attenuation8m*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_attenuation"
+else
+	echo "WARNING: Unable to establish DetVar type."
+        echo "Setting this to tbe the CV sample."
+        echo "Please check fhicls to ensure this is correct."
+        flag_redk2nu="true"
+fi
+
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_redk2nu}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_kdar_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_kdar_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="kdar_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="true"
+beam="numi"
+horncur='_rhc'
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_kdar_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_kdar_overlay_detvar.sh
@@ -1,0 +1,160 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+
+
+sample_type='kdar_overlay'
+flag_SaveLeeWeights="false"
+flag_numi="true"
+flag_redk2nu="false"
+beam="numi"
+horncur="_rhc"
+
+
+
+detvar_type="cv"
+if ls *reg4_SCE*.fcl 1> /dev/null 2>&1; then
+	detvar_type="SCE"
+elif ls *reg4_recombination*.fcl 1> /dev/null 2>&1; then
+        detvar_type="recombination"
+elif ls *wiremod_ScaleX*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMX"
+elif ls *wiremod_ScaleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMYZ"
+elif ls *wiremod_ScaleAngleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaYZ"
+elif ls *wiremod_ScaleAngleXZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaXZ"
+elif ls *reg4_LY_reyliegh*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_reyliegh"
+elif ls *reg4_LY_suppression75*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_down"
+elif ls *reg4_LY_attenuation8m*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_attenuation"
+else
+	echo "WARNING: Unable to establish DetVar type."
+        echo "Setting this to tbe the CV sample."
+        echo "Please check fhicls to ensure this is correct."
+        flag_redk2nu="true"
+fi
+
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_redk2nu}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_ncpi0_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_ncpi0_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="ncpi0_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="true"
+beam="numi"
+horncur='_rhc'
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_ncpi0_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_ncpi0_overlay_detvar.sh
@@ -1,0 +1,160 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+
+
+sample_type='ncpi0_overlay'
+flag_SaveLeeWeights="false"
+flag_numi="true"
+flag_redk2nu="false"
+beam="numi"
+horncur="_rhc"
+
+
+
+detvar_type="cv"
+if ls *reg4_SCE*.fcl 1> /dev/null 2>&1; then
+	detvar_type="SCE"
+elif ls *reg4_recombination*.fcl 1> /dev/null 2>&1; then
+        detvar_type="recombination"
+elif ls *wiremod_ScaleX*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMX"
+elif ls *wiremod_ScaleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMYZ"
+elif ls *wiremod_ScaleAngleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaYZ"
+elif ls *wiremod_ScaleAngleXZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaXZ"
+elif ls *reg4_LY_reyliegh*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_reyliegh"
+elif ls *reg4_LY_suppression75*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_down"
+elif ls *reg4_LY_attenuation8m*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_attenuation"
+else
+	echo "WARNING: Unable to establish DetVar type."
+        echo "Setting this to tbe the CV sample."
+        echo "Please check fhicls to ensure this is correct."
+        flag_redk2nu="true"
+fi
+
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_redk2nu}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_nu_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_nu_overlay.sh
@@ -1,0 +1,130 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="nu_overlay"
+flag_SaveLeeWeights="false"
+flag_numi="true"
+beam="numi"
+horncur='_rhc'
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_nu_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_nu_overlay_detvar.sh
@@ -1,0 +1,160 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+
+
+sample_type='nu_overlay'
+flag_SaveLeeWeights="false"
+flag_numi="true"
+flag_redk2nu="false"
+beam="numi"
+horncur="_rhc"
+
+
+
+detvar_type="cv"
+if ls *reg4_SCE*.fcl 1> /dev/null 2>&1; then
+	detvar_type="SCE"
+elif ls *reg4_recombination*.fcl 1> /dev/null 2>&1; then
+        detvar_type="recombination"
+elif ls *wiremod_ScaleX*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMX"
+elif ls *wiremod_ScaleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMYZ"
+elif ls *wiremod_ScaleAngleYZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaYZ"
+elif ls *wiremod_ScaleAngleXZ*.fcl 1> /dev/null 2>&1; then
+        detvar_type="WMThetaXZ"
+elif ls *reg4_LY_reyliegh*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_reyliegh"
+elif ls *reg4_LY_suppression75*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_down"
+elif ls *reg4_LY_attenuation8m*.fcl 1> /dev/null 2>&1; then
+        detvar_type="LY_attenuation"
+else
+	echo "WARNING: Unable to establish DetVar type."
+        echo "Setting this to tbe the CV sample."
+        echo "Please check fhicls to ensure this is correct."
+        flag_redk2nu="true"
+fi
+
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_redk2nu}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_detvar_${detvar_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_nuwro_fakedata.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_nuwro_fakedata.sh
@@ -1,0 +1,136 @@
+#! /bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl using the initilization source hook. It
+#          makes a wrapper fcl file that overrides certain fcl
+#          parameters used by module WireCellAnaTree and
+#          WireCellEventWeightTree, specifically:
+#        
+#          physics.analyzers.wcpselection.FileType: "data_extbnb_run3_G1"
+#          physics.analyzers.wcpweights.FileType: "data_extbnb_run3_G1"
+#
+# Created: Wenqiang Gu, 14-Jan-2021
+#         
+# Updated: Liang Liu,   03-Jan-2025
+#          Unified this script for all runs
+#
+#------------------------------------------------------------------
+
+# Make sure batch environment variables needed by this script are defined.
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# Rename the existing fcl file $FCL to something else.
+
+mv $FCL mix_wrapper.fcl
+
+# Generate wrapper according to run_number
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+echo $next_stage_input
+# get the run number
+run_number=`echo $next_stage_input | cut -d '-' -f3`
+echo $run_number
+
+FT_STREAM="run1"
+
+if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
+then
+        echo "run run1 fhicl"
+        FT_STREAM="run1"
+elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2a fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
+then
+        echo "run run2b fhicl"
+        FT_STREAM="run2"
+elif [ "$run_number" -ge "0013697"  ] && [  "0014116" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3a fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "14117"  ] && [  "0018960" -ge "$run_number"  ];    # in the run3 run number interval
+then
+        echo "run run3b fhicl"
+        FT_STREAM="run3"
+elif [ "$run_number" -ge "0018961"  ] && [  "0019752" -ge "$run_number"  ];  # in the run4 run number interval, run4a has four epochs, we may need to split it
+then
+        echo "run run4a fhicl"
+        FT_STREAM="run4a"
+elif [ "$run_number" -ge "0019753"  ] && [  "0021285" -ge "$run_number"  ];  # in the run4 run number interval, run4b has four epochs, we may need to split it
+then
+        echo "run run4b fhicl"
+        FT_STREAM="run4b"
+elif [ "$run_number" -ge "0021286"  ] && [  "0022269" -ge "$run_number"  ];  # in the run4 run number interval, run4c has four epochs, we may need to split it
+then
+        echo "run run4c fhicl"
+        FT_STREAM="run4c"
+elif [ "$run_number" -ge "0022270"  ] && [  "0024319" -ge "$run_number"  ];  # in the run4 run number interval, run4d has four epochs, we may need to split it
+then
+        echo "run run4d fhicl"
+        FT_STREAM="run4d"
+elif [ "$run_number" -ge "0024320"  ] && [  "0025768" -ge "$run_number"  ];  # in the run5 run number interval
+then
+        echo "run run5 fhicl"
+        FT_STREAM="run5"
+fi
+
+sample_type="nuwro_fakedata"
+flag_SaveLeeWeights="false"
+flag_numi="true"
+beam="numi"
+horncur='_rhc'
+
+cat <<EOF > $FCL
+#include "mix_wrapper.fcl"
+
+physics.analyzers.wcpselection.MC:              true
+physics.analyzers.wcpselection.SaveWeights:     false
+physics.analyzers.wcpselection.POT_inputTag:    "generator"
+
+
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
+physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
+
+physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
+
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
+
+physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
+physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
+
+
+physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
+
+physics.ana: [wcpselection]
+physics.end_paths: [ stream1, ana ]
+
+services.TFileService.fileName: 	"reco_stage_2_hist.root"
+microboone_tfile_metadata.JSONFileName: ["reco_stage_2_hist.root.json"]
+
+EOF
+
+# Make sure IFDH service is configured in fcl file.
+
+if ! lar --debug-config=/dev/stdout -c $FCL | grep -q IFDH:; then
+  cat <<EOF >> $FCL
+services.IFDH:
+{
+}
+
+EOF
+fi
+

--- a/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_numi_WCP_00_17_00.sh
+++ b/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_numi_WCP_00_17_00.sh
@@ -30,10 +30,7 @@ cp $wc_input_celltree WCPwork/
 
 echo "set up additional environment for wirecell" | tee -a wirecell.log
 cd WCPwork 
-#setup numpy v1_14_3 -q e17:openblas:p2714b:prof
-#setup libtorch v1_0_1 -q e17:prof
-#setup SparseConvNet 8422a6f -q e17:prof
-setup SparseConvNet v01_00_00
+setup scn v01_00_00
 export PYTHONPATH=$WCP_FQ_DIR/python:$PYTHONPATH #may not needed any longer; already appened in uboonecode
 
 echo "Create symlink to stash dCache WCP external data files" | tee -a ../wirecell.log

--- a/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_overlay_WCP_00_17_00.sh
+++ b/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_overlay_WCP_00_17_00.sh
@@ -30,10 +30,7 @@ cp $wc_input_celltree WCPwork/
 
 echo "set up additional environment for wirecell" | tee -a wirecell.log
 cd WCPwork 
-#setup numpy v1_14_3 -q e17:openblas:p2714b:prof
-#setup libtorch v1_0_1 -q e17:prof
-#setup SparseConvNet 8422a6f -q e17:prof
-setup SparseConvNet v01_00_00
+setup scn v01_00_00
 export PYTHONPATH=$WCP_FQ_DIR/python:$PYTHONPATH #may not needed any longer; already appened in uboonecode
 
 echo "Create symlink to stash dCache WCP external data files" | tee -a ../wirecell.log

--- a/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_overlay_numi_WCP_00_17_00.sh
+++ b/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_overlay_numi_WCP_00_17_00.sh
@@ -30,10 +30,7 @@ cp $wc_input_celltree WCPwork/
 
 echo "set up additional environment for wirecell" | tee -a wirecell.log
 cd WCPwork 
-#setup numpy v1_14_3 -q e17:openblas:p2714b:prof
-#setup libtorch v1_0_1 -q e17:prof
-#setup SparseConvNet 8422a6f -q e17:prof
-setup SparseConvNet v01_00_00
+setup scn v01_00_00
 export PYTHONPATH=$WCP_FQ_DIR/python:$PYTHONPATH #may not needed any longer; already appened in uboonecode
 
 echo "Create symlink to stash dCache WCP external data files" | tee -a ../wirecell.log

--- a/ubana/MicroBooNEWireCell/utils/update_wcpf_port.sh
+++ b/ubana/MicroBooNEWireCell/utils/update_wcpf_port.sh
@@ -28,11 +28,25 @@ fi
 
 mv $FCL wrapper_update_wcpf_port.fcl
 
+flag_numi="false"
+if ls Physics*numi*.root 1> /dev/null 2>&1 || ls Beam*numi*.root 1> /dev/null 2>&1 ; then
+        flag_numi="true"
+        echo Running NuMI fhcl
+elif ls *numi*.fcl 1> /dev/null 2>&1; then
+        flag_numi="true"
+        echo Running NuMI fhcl
+else
+	echo Running BNB fhcl
+fi
+
+
+
 # Generate wrapper.
 
 cat <<EOF > $FCL
 #include "wrapper_update_wcpf_port.fcl"
 
+physics.producers.wirecellPF.ssmBDT:                      ${flag_numi}
 physics.producers.wirecellPF.PFInput_prefix:              "WCPwork/nue"
 
 EOF


### PR DESCRIPTION
The helper scripts used during Wire-Cell production have been updated and added to uboone code. Instead of using four different unified_reco2_wirecell*.sh scripts, there is only one: fully_unified_reco2_wirecell.sh. The relevant celltree making fhicl still needs to change across data, MC, and some of the detvars. Instead of having different update_slimmed_port*.sh, for data and MC, these have been consolidated to one. All def_filetype* scripts have also been added, and consolidated across data/ext, consolidated across runs, and consolidated across detvar types.