### PR TITLE
Integrate LArPID network, MC back tracking from larcv images and write outputs in Wire-Cell ntuple maker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ cet_report_compiler_flags(REPORT_THRESHOLD VERBOSE)
 cet_cmake_module_directories(Modules BINARY)
 
 find_package( ubreco REQUIRED EXPORT )
+find_package( ubcv REQUIRED EXPORT )
 find_package( larana REQUIRED EXPORT )
 find_package( larpandora REQUIRED EXPORT )
 find_package( swtrigger REQUIRED EXPORT )

--- a/ubana/CombinedReco/run_combinedrecotree.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree.fcl
@@ -100,6 +100,15 @@ physics:
       save_track_position:      false
       PFDump_min_truth_energy:  0.010 # GeV
       
+      # LANTERN integration options
+      RunLArPID:          false
+      LArPIDModel:        "LArPID_default_network_weights_torchscript_v2_model.pt"
+      PixelThreshold:     5
+      AllPlaneThreshold:  true
+      LArCVImageFile:     "merged_dlreco.root"
+      TickBack:           false
+      RunBackTracking:    false
+
       # nanosecond beam timing
       SaveSPS:              true
       SavePMT:              true

--- a/ubana/CombinedReco/run_combinedrecotree.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree.fcl
@@ -101,7 +101,7 @@ physics:
       PFDump_min_truth_energy:  0.010 # GeV
       
       # LANTERN integration options
-      RunLArPID:          false
+      RunLArPID:          true
       LArPIDModel:        "LArPID_default_network_weights_torchscript_v2_model.pt"
       PixelThreshold:     5
       AllPlaneThreshold:  true

--- a/ubana/CombinedReco/run_combinedrecotree_overlay.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree_overlay.fcl
@@ -28,7 +28,7 @@ physics.filters.nuselection.IsData: false
 ###physics.producers.shrreco3dKalmanShowercali: @local::shrreco3dKalmanShowercalimc
 
 physics.analyzers.wcpselection.MC:		true
-physics.analyzers.wcpselection.RunBackTracking:	false
+physics.analyzers.wcpselection.RunBackTracking:	true
 physics.analyzers.wcpselection.SaveWeights:	true
 physics.analyzers.wcpselection.POT_inputTag:	"generator"
 

--- a/ubana/CombinedReco/run_combinedrecotree_overlay.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree_overlay.fcl
@@ -28,6 +28,7 @@ physics.filters.nuselection.IsData: false
 ###physics.producers.shrreco3dKalmanShowercali: @local::shrreco3dKalmanShowercalimc
 
 physics.analyzers.wcpselection.MC:		true
+physics.analyzers.wcpselection.RunBackTracking:	false
 physics.analyzers.wcpselection.SaveWeights:	true
 physics.analyzers.wcpselection.POT_inputTag:	"generator"
 

--- a/ubana/MicroBooNEWireCell/CMakeLists.txt
+++ b/ubana/MicroBooNEWireCell/CMakeLists.txt
@@ -22,6 +22,9 @@ cet_build_plugin(
   LIBRARIES
   PRIVATE
   ubobj::WcpPort
+  ubcv::LArCVImageMaker
+  larcv::DataFormat
+  larlite::DataFormat
   larsim::EventWeight_Base
   larevt::SpaceChargeService
   larevt::PmtGainService

--- a/ubana/MicroBooNEWireCell/job/run_wcanatree.fcl
+++ b/ubana/MicroBooNEWireCell/job/run_wcanatree.fcl
@@ -62,7 +62,7 @@ physics:
       PFDump_min_truth_energy:  0.010 # GeV
 
       # LANTERN integration options
-      RunLArPID:          true
+      RunLArPID:          false
       LArPIDModel:        "LArPID_default_network_weights_torchscript_v2_model.pt"
       PixelThreshold:     5
       AllPlaneThreshold:  true

--- a/ubana/MicroBooNEWireCell/job/run_wcanatree.fcl
+++ b/ubana/MicroBooNEWireCell/job/run_wcanatree.fcl
@@ -62,7 +62,7 @@ physics:
       PFDump_min_truth_energy:  0.010 # GeV
 
       # LANTERN integration options
-      RunLArPID:          false
+      RunLArPID:          true
       LArPIDModel:        "LArPID_default_network_weights_torchscript_v2_model.pt"
       PixelThreshold:     5
       AllPlaneThreshold:  true

--- a/ubana/MicroBooNEWireCell/job/run_wcanatree.fcl
+++ b/ubana/MicroBooNEWireCell/job/run_wcanatree.fcl
@@ -61,6 +61,15 @@ physics:
       save_track_position:      false
       PFDump_min_truth_energy:  0.010 # GeV
 
+      # LANTERN integration options
+      RunLArPID:          true
+      LArPIDModel:        "LArPID_default_network_weights_torchscript_v2_model.pt"
+      PixelThreshold:     5
+      AllPlaneThreshold:  true
+      LArCVImageFile:     "merged_dlreco.root"
+      TickBack:           false
+      RunBackTracking:    false
+
       MCS:          true
 
       # nanosecond beam timing

--- a/ubana/MicroBooNEWireCell/job/run_wcanatree_overlay.fcl
+++ b/ubana/MicroBooNEWireCell/job/run_wcanatree_overlay.fcl
@@ -1,7 +1,7 @@
 #include "run_wcanatree.fcl"
 
 physics.analyzers.wcpselection.MC:		true
-physics.analyzers.wcpselection.RunBackTracking:	false
+physics.analyzers.wcpselection.RunBackTracking:	true
 physics.analyzers.wcpselection.SaveWeights:	true
 physics.analyzers.wcpselection.POT_inputTag:	"generator"
 

--- a/ubana/MicroBooNEWireCell/job/run_wcanatree_overlay.fcl
+++ b/ubana/MicroBooNEWireCell/job/run_wcanatree_overlay.fcl
@@ -1,6 +1,7 @@
 #include "run_wcanatree.fcl"
 
 physics.analyzers.wcpselection.MC:		true
+physics.analyzers.wcpselection.RunBackTracking:	true
 physics.analyzers.wcpselection.SaveWeights:	true
 physics.analyzers.wcpselection.POT_inputTag:	"generator"
 

--- a/ubana/MicroBooNEWireCell/job/run_wcanatree_overlay.fcl
+++ b/ubana/MicroBooNEWireCell/job/run_wcanatree_overlay.fcl
@@ -1,7 +1,7 @@
 #include "run_wcanatree.fcl"
 
 physics.analyzers.wcpselection.MC:		true
-physics.analyzers.wcpselection.RunBackTracking:	true
+physics.analyzers.wcpselection.RunBackTracking:	false
 physics.analyzers.wcpselection.SaveWeights:	true
 physics.analyzers.wcpselection.POT_inputTag:	"generator"
 

--- a/ubana/MicroBooNEWireCell/job/run_wcanatree_overlay_altLArPIDWeights.fcl
+++ b/ubana/MicroBooNEWireCell/job/run_wcanatree_overlay_altLArPIDWeights.fcl
@@ -1,0 +1,3 @@
+#include "run_wcanatree_overlay.fcl"
+
+physics.analyzers.wcpselection.LArPIDModel: "LArPID_alternate_network_weights_torchscript_v2_model.pt"

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -252,6 +252,7 @@ larana		v10_00_12	-
 larpandora	v10_00_15	-
 ubraw		v10_04_05	-
 ubreco		v10_04_06	-
+ubcv            v10_04_05	-	only_for_build
 cetmodules	v3_24_01	-	only_for_build
 end_product_list
 ####################################
@@ -307,15 +308,15 @@ end_product_list
 #   case it is optional.
 #
 ####################################
-qualifier	ubreco		ubraw		larana		larpandora
-c14:debug       c14:debug       c14:debug       c14:debug       c14:debug
-c14:prof        c14:prof        c14:prof        c14:prof        c14:prof
-c7:debug	c7:debug	c7:debug	c7:debug	c7:debug
-c7:prof		c7:prof		c7:prof		c7:prof		c7:prof
-e26:debug       e26:debug       e26:debug       e26:debug       e26:debug
-e26:prof        e26:prof        e26:prof        e26:prof        e26:prof
-e20:debug	e20:debug	e20:debug	e20:debug	e20:debug
-e20:prof	e20:prof	e20:prof	e20:prof	e20:prof
+qualifier	ubreco		ubraw		larana		larpandora        ubcv
+c14:debug       c14:debug       c14:debug       c14:debug       c14:debug         c14:debug
+c14:prof        c14:prof        c14:prof        c14:prof        c14:prof          c14:prof
+c7:debug	c7:debug	c7:debug	c7:debug	c7:debug          c7:debug
+c7:prof		c7:prof		c7:prof		c7:prof		c7:prof           c7:prof
+e26:debug       e26:debug       e26:debug       e26:debug       e26:debug         e26:debug
+e26:prof        e26:prof        e26:prof        e26:prof        e26:prof          e26:prof
+e20:debug	e20:debug	e20:debug	e20:debug	e20:debug         e20:debug
+e20:prof	e20:prof	e20:prof	e20:prof	e20:prof          e20:prof
 end_qualifier_list
 ####################################
 


### PR DESCRIPTION
This PR updates WireCellAnaTree_module.cc (which creates Wire-Cell ntuples) to call new interfaces from ubcv to run LANTERN's LArPID network and MC backtracking over particles reconstructed in wire-cell.

This PR depends on updates in the following ublite and ubcv pull requests:
https://github.com/uboone/ubcv/pull/1
https://github.com/uboone/ublite/pull/1
Those PRs must be included along with this one