### PR TITLE
save particle G4trackID and mother for blip ancestry determination

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 find_package(cetmodules REQUIRED)
-project(ubana VERSION 10.04.07.01 LANGUAGES CXX)
+project(ubana VERSION 10.04.07.02 LANGUAGES CXX)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 find_package(cetmodules REQUIRED)
-project(ubana VERSION 10.04.07.02 LANGUAGES CXX)
+project(ubana VERSION 10.04.07.03 LANGUAGES CXX)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/ubana/searchingfornues/Selection/AnalysisTools/DefaultAnalysis_tool.cc
+++ b/ubana/searchingfornues/Selection/AnalysisTools/DefaultAnalysis_tool.cc
@@ -285,6 +285,8 @@ private:
   unsigned int _hits_v;
   unsigned int _hits_y;
 
+  std::vector<int> _mc_trackid;     // G4 Track ID
+  std::vector<int> _mc_mother;      // mother TrackID
   std::vector<int> _mc_pdg;
   std::vector<float> _mc_E;
   std::vector<uint> _mc_n_elastic; // number of elastic scatters
@@ -1189,6 +1191,8 @@ void DefaultAnalysis::setBranches(TTree *_tree)
   _tree->Branch("topological_score", &_topo_score, "topological_score/F");
   _tree->Branch("slclustfrac", &slclustfrac, "slclustfrac/F");
 
+  _tree->Branch("mc_trackid", "std::vector< int >", &_mc_trackid);
+  _tree->Branch("mc_mother", "std::vector< int >", &_mc_mother);
   _tree->Branch("mc_pdg", "std::vector< int >", &_mc_pdg);
   _tree->Branch("mc_E", "std::vector< float >", &_mc_E);
 
@@ -1397,6 +1401,8 @@ void DefaultAnalysis::resetTTree(TTree *_tree)
   _mc_E.clear();
   _mc_n_elastic.clear();
   _mc_n_inelastic.clear();
+  _mc_trackid.clear();
+  _mc_mother.clear();
   _mc_pdg.clear();
 
   _mc_px.clear();
@@ -1687,7 +1693,9 @@ void DefaultAnalysis::SaveTruth(art::Event const &e)
     }
 
     _mc_E.push_back(mcp.E());
-
+    
+    _mc_trackid.push_back(mcp.TrackId());
+    _mc_mother.push_back(mcp.Mother());
     _mc_pdg.push_back(mcp.PdgCode());
 
     auto nElastic = 0u;

--- a/ubana/searchingfornues/Selection/AnalysisTools/NeutrinoTiming_tool.cc
+++ b/ubana/searchingfornues/Selection/AnalysisTools/NeutrinoTiming_tool.cc
@@ -251,7 +251,10 @@ namespace analysis
       H_time= tfs->make<TH1F>("H_time","Time PMT",2000, 0,20000);
       H_maxH= tfs->make<TH1F>("H_maxH","Max amplitude",2400,1800,2100);
       H_t0_Beam= tfs->make<TH1F>("H_t0_Beam","T_0 beam",300,0,150);
-      H_TimeVsPh= tfs->make<TH2F>("H_TimeVsPh","H_TimeVsPh",  100, -50,50,  100, 0,500);
+      H_TimeVsPh= tfs->make<TH2F>("H_TimeVsPh","H_TimeVsPh",  100, -50,50,  100, 0,1500);
+      H_TruthTime = tfs->make<TH1F>("H_Truthtime","H_Truthtime",  100, 2000, 5000);
+      H_SimTime   = tfs->make<TH1F>("H_SimTime","H_SimTime",  100, 2000, 7000);
+      H_ns_time   = tfs->make<TH1F>("H_ns_time","H_ns_time",  100, 2000, 7000);
     }else{
       H_time      = tfs->make<TH1F>("H_time","Time PMT",500, 0,6000);
       H_maxH      = tfs->make<TH1F>("H_maxH","Max amplitude",800,2000,2100);
@@ -665,7 +668,7 @@ namespace analysis
 	      maxZhelp1=maxZ/Frac[FB]; tick=tickF; Nss=0; is=0;
         for(int i=3*64; i<samples_64*64; i++){if(Raw_wf_v[i]<4095){Nss=Nss+1;}}
       
-        double txSS[256],tySS[256],txSS2[256],tySS2[256];
+        double txSS[1500],tySS[1500],txSS2[1500],tySS2[1500];
       
         for(int i=3*64; i<samples_64*64; i++){if(Raw_wf_v[i]<4095){txSS[is]=i*1.0; tySS[is]=Raw_wf_v[i]/maxZhelp1; is=is+1;}}
         TGraph *g1 = new TGraph(Nss,txSS,tySS);
@@ -855,7 +858,7 @@ namespace analysis
       get_sim_time(e);
 
       RWM_T=BeamT0;
-      //std::cout << "[NeutrinoTimingDebug] RWM_T : " << RWM_T << std::endl;
+      std::cout << "[NeutrinoTimingDebug] RWM_T : " << RWM_T << std::endl;
       double dist = z;
       
       if(f_isnumi) {
@@ -866,7 +869,7 @@ namespace analysis
         dist = ( (min_a-x)*target_dir[0] + (min_b-y)*target_dir[1] + (min_c-z)*target_dir[2] ) / sqrt(target_dir[0]*target_dir[0] + target_dir[1]*target_dir[1] + target_dir[2]*target_dir[2] );
       }
       nuToF=dist*0.033356;
-      //std::cout << "[NeutrinoTimingDebug] nuToF : " << nuToF << std::endl;
+      std::cout << "[NeutrinoTimingDebug] nuToF : " << nuToF << std::endl;
       std::vector<double> timeProp = std::vector<double>(N_pmt.size(),0);
       for(uint i=0; i<N_pmt.size(); i++){
         tp=5000000000.0;
@@ -877,7 +880,7 @@ namespace analysis
           if(tPhelp<tp){tp=tPhelp;}
         }
         timeProp[i]=tp;
-        //std::cout << "[NeutrinoTimingDebug] timeProp: " << timeProp[i] << std::endl;
+        std::cout << "[NeutrinoTimingDebug] timeProp: " << timeProp[i] << std::endl;
       }
      
       double TT3_array[32];
@@ -906,9 +909,9 @@ namespace analysis
 	
 	      //all the corrections
 	      TT3_array[i]=(time[N_pmt.at(i)])-RWM_T+RWM_offset-nuToF-timeProp[i]-offset[N_pmt.at(i)]+ccnd1+ccnd2+ccnd3;
-        //std::cout << "[NeutrinoTimingDebug] timeProp: " << timeProp[i] << std::endl;
-        //std::cout << "[NeutrinoTimingDebug] PMT time: " << time[N_pmt.at(i)]<< std::endl;
-        //std::cout << "[NeutrinoTimingDebug] Corrected PMT " << i << " timing " << TT3_array[i] << std::endl;
+        std::cout << "[NeutrinoTimingDebug] timeProp: " << timeProp[i] << std::endl;
+        std::cout << "[NeutrinoTimingDebug] PMT time: " << time[N_pmt.at(i)]<< std::endl;
+        std::cout << "[NeutrinoTimingDebug] Corrected PMT " << i << " timing " << TT3_array[i] << std::endl;
       }
       Med_TT3=TMath::Median((Long64_t)N_pmt.size(),TT3_array);
       //Fill a 2d histogram with  TT3_array[i] vs max[N_pmt.at(i)] this is usefull to check for any errors

--- a/ubana/searchingfornues/Selection/AnalysisTools/NeutrinoTiming_tool.cc
+++ b/ubana/searchingfornues/Selection/AnalysisTools/NeutrinoTiming_tool.cc
@@ -498,7 +498,7 @@ namespace analysis
       _mc_interaction_time = f_sim_time;
     }
 
-    std::cout << "[NeutrinoTimingDebug] interaction_time_abs: " << _interaction_time_abs << " interaction_time_modulo: "<< _interaction_time_modulo << " mc_interaction_time: " << _mc_interaction_time << " time_offset: "<< _time_offset << std::endl;
+    //std::cout << "[NeutrinoTimingDebug] interaction_time_abs: " << _interaction_time_abs << " interaction_time_modulo: "<< _interaction_time_modulo << " mc_interaction_time: " << _mc_interaction_time << " time_offset: "<< _time_offset << std::endl;
   
   return;
   }
@@ -858,7 +858,7 @@ namespace analysis
       get_sim_time(e);
 
       RWM_T=BeamT0;
-      std::cout << "[NeutrinoTimingDebug] RWM_T : " << RWM_T << std::endl;
+      //std::cout << "[NeutrinoTimingDebug] RWM_T : " << RWM_T << std::endl;
       double dist = z;
       
       if(f_isnumi) {
@@ -869,7 +869,7 @@ namespace analysis
         dist = ( (min_a-x)*target_dir[0] + (min_b-y)*target_dir[1] + (min_c-z)*target_dir[2] ) / sqrt(target_dir[0]*target_dir[0] + target_dir[1]*target_dir[1] + target_dir[2]*target_dir[2] );
       }
       nuToF=dist*0.033356;
-      std::cout << "[NeutrinoTimingDebug] nuToF : " << nuToF << std::endl;
+      //std::cout << "[NeutrinoTimingDebug] nuToF : " << nuToF << std::endl;
       std::vector<double> timeProp = std::vector<double>(N_pmt.size(),0);
       for(uint i=0; i<N_pmt.size(); i++){
         tp=5000000000.0;
@@ -880,7 +880,7 @@ namespace analysis
           if(tPhelp<tp){tp=tPhelp;}
         }
         timeProp[i]=tp;
-        std::cout << "[NeutrinoTimingDebug] timeProp: " << timeProp[i] << std::endl;
+        //std::cout << "[NeutrinoTimingDebug] timeProp: " << timeProp[i] << std::endl;
       }
      
       double TT3_array[32];
@@ -909,9 +909,9 @@ namespace analysis
 	
 	      //all the corrections
 	      TT3_array[i]=(time[N_pmt.at(i)])-RWM_T+RWM_offset-nuToF-timeProp[i]-offset[N_pmt.at(i)]+ccnd1+ccnd2+ccnd3;
-        std::cout << "[NeutrinoTimingDebug] timeProp: " << timeProp[i] << std::endl;
-        std::cout << "[NeutrinoTimingDebug] PMT time: " << time[N_pmt.at(i)]<< std::endl;
-        std::cout << "[NeutrinoTimingDebug] Corrected PMT " << i << " timing " << TT3_array[i] << std::endl;
+        //std::cout << "[NeutrinoTimingDebug] timeProp: " << timeProp[i] << std::endl;
+        //std::cout << "[NeutrinoTimingDebug] PMT time: " << time[N_pmt.at(i)]<< std::endl;
+        //std::cout << "[NeutrinoTimingDebug] Corrected PMT " << i << " timing " << TT3_array[i] << std::endl;
       }
       Med_TT3=TMath::Median((Long64_t)N_pmt.size(),TT3_array);
       //Fill a 2d histogram with  TT3_array[i] vs max[N_pmt.at(i)] this is usefull to check for any errors

--- a/ubana/searchingfornues/Selection/job/numi/run_neutrinoselectionfilter_run3_overlay_cc0pinp_numi.fcl
+++ b/ubana/searchingfornues/Selection/job/numi/run_neutrinoselectionfilter_run3_overlay_cc0pinp_numi.fcl
@@ -1,4 +1,4 @@
-#include "run_neutrinoselectionfilter_run1_overlay_numi.fcl"
+#include "run_neutrinoselectionfilter_run3_overlay_numi.fcl"
 
 physics.filters.nuselection.AnalysisTools.crtApproach:   @local::CRTApproachAnalysisTool
 physics.filters.nuselection.AnalysisTools.crtApproach.TrackAssnModuleLabel:   "crttrackmatch"

--- a/ubana/searchingfornues/Selection/job/numi/run_neutrinoselectionfilter_run3_overlay_numi.fcl
+++ b/ubana/searchingfornues/Selection/job/numi/run_neutrinoselectionfilter_run3_overlay_numi.fcl
@@ -14,4 +14,5 @@ physics.filters.nuselection.AnalysisTools.default.CRTVetoproducer: "crtveto"
 physics.filters.nuselection.AnalysisTools.zbdt.TrigResProducer: "TriggerResults::OverlayFiltersPostStage2"
 physics.filters.nuselection.AnalysisTools.timing.isRun3: true
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "DataOverlayNoTPC"
 

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -251,8 +251,8 @@ product		version		qual	flags		<table_format=2>
 larana		v10_00_13	-
 larpandora	v10_00_16	-
 ubraw		v10_04_05	-
-ubreco		v10_04_07_01	-
-ubcv            v10_04_07_01	-
+ubreco		v10_04_07_02	-
+ubcv            v10_04_07_02	-
 cetmodules	v3_24_01	-	only_for_build
 end_product_list
 ####################################


### PR DESCRIPTION
Saving of two additional pieces of information (both ints) that will make it easier to determine the origin of particles that get truth-matched to blips