### PR TITLE
Removing MC timing calibration as default

### DIFF
--- a/ubana/CombinedReco/run_combinedrecotree_overlay.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree_overlay.fcl
@@ -37,4 +37,18 @@ physics.analyzers.wcpselection.POT_inputTag:	"generator"
 physics.analyzers.wcpweights.SaveWeights:	true
 physics.analyzers.wcpweights.SaveFullWeights:	true
 
+physics.analyzers.wcpselection.ccnd1_a: 0
+physics.analyzers.wcpselection.ccnd1_b: 0
+physics.analyzers.wcpselection.ccnd2_a: 0
+physics.analyzers.wcpselection.ccnd2_b: 0
+physics.analyzers.wcpselection.ccnd3_a: 0
+physics.analyzers.wcpselection.ccnd3_b: 0
+physics.analyzers.wcpselection.ccnd3_c: 0
+physics.analyzers.wcpselection.ccnd3_d: 0
+physics.analyzers.wcpselection.ccnd4_a: 0
+physics.analyzers.wcpselection.ccnd4_b: 0
+physics.analyzers.wcpselection.ccnd4_2_a: 0
+physics.analyzers.wcpselection.ccnd4_2_b: 0
+physics.analyzers.wcpselection.dist_cut_x_cor: 99999
+
 physics.ana: [wcpselection, wcpweights]

--- a/ubana/MicroBooNEWireCell/job/run_wcanatree_overlay.fcl
+++ b/ubana/MicroBooNEWireCell/job/run_wcanatree_overlay.fcl
@@ -8,18 +8,18 @@ physics.analyzers.wcpselection.POT_inputTag:	"generator"
 physics.analyzers.wcpweights.SaveWeights:	true
 physics.analyzers.wcpweights.SaveFullWeights:	true
 
-physics.analyzers.wcpselection.ccnd1_a: 0.17956 
-physics.analyzers.wcpselection.ccnd1_b: 2.604
+physics.analyzers.wcpselection.ccnd1_a: 0 
+physics.analyzers.wcpselection.ccnd1_b: 0
 physics.analyzers.wcpselection.ccnd2_a: 0 
 physics.analyzers.wcpselection.ccnd2_b: 0 
 physics.analyzers.wcpselection.ccnd3_a: 0
 physics.analyzers.wcpselection.ccnd3_b: 0
 physics.analyzers.wcpselection.ccnd3_c: 0
 physics.analyzers.wcpselection.ccnd3_d: 0
-physics.analyzers.wcpselection.ccnd4_a: -0.0338 
-physics.analyzers.wcpselection.ccnd4_b: -2.8479
-physics.analyzers.wcpselection.ccnd4_2_a: 0.0124
-physics.analyzers.wcpselection.ccnd4_2_b: 4.4716
-physics.analyzers.wcpselection.dist_cut_x_cor: 150
+physics.analyzers.wcpselection.ccnd4_a: 0 
+physics.analyzers.wcpselection.ccnd4_b: 0
+physics.analyzers.wcpselection.ccnd4_2_a: 0
+physics.analyzers.wcpselection.ccnd4_2_b: 0
+physics.analyzers.wcpselection.dist_cut_x_cor: 99999
 
 physics.ana: [wcpselection, wcpweights]

--- a/ubana/MicroBooNEWireCell/job/run_wcanatree_overlay_numi_oldflux_rw.fcl
+++ b/ubana/MicroBooNEWireCell/job/run_wcanatree_overlay_numi_oldflux_rw.fcl
@@ -60,16 +60,16 @@ physics.analyzers.wcpweights.GenieKnobs:        [ "All_UBGenie"
                                                 , "xsr_scc_Fv3_SCC" ]
 
 
-physics.analyzers.wcpselection.ccnd1_a: 0.17956
-physics.analyzers.wcpselection.ccnd1_b: 2.604
+physics.analyzers.wcpselection.ccnd1_a: 0
+physics.analyzers.wcpselection.ccnd1_b: 0
 physics.analyzers.wcpselection.ccnd2_a: 0
 physics.analyzers.wcpselection.ccnd2_b: 0
 physics.analyzers.wcpselection.ccnd3_a: 0
 physics.analyzers.wcpselection.ccnd3_b: 0
 physics.analyzers.wcpselection.ccnd3_c: 0
 physics.analyzers.wcpselection.ccnd3_d: 0
-physics.analyzers.wcpselection.ccnd4_a: -0.0338
-physics.analyzers.wcpselection.ccnd4_b: -2.8479
-physics.analyzers.wcpselection.ccnd4_2_a: 0.0124
-physics.analyzers.wcpselection.ccnd4_2_b: 4.4716
-physics.analyzers.wcpselection.dist_cut_x_cor: 150
+physics.analyzers.wcpselection.ccnd4_a: 0
+physics.analyzers.wcpselection.ccnd4_b: 0
+physics.analyzers.wcpselection.ccnd4_2_a: 0
+physics.analyzers.wcpselection.ccnd4_2_b: 0
+physics.analyzers.wcpselection.dist_cut_x_cor: 99999

--- a/ubana/MicroBooNEWireCell/utils/def_filetype.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype.sh
@@ -139,6 +139,7 @@ cat <<EOF > $FCL
 
 physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
 
+physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpselection.ccnd1_a: ${ccnd1_a} 
 physics.analyzers.wcpselection.ccnd1_b: ${ccnd1_b}
 physics.analyzers.wcpselection.ccnd2_a: ${ccnd2_a} 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ccpi0_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ccpi0_overlay.sh
@@ -103,7 +103,7 @@ physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
 
 physics.analyzers.wcpselection.get_reboone_time:     true
-physics.analyzers.wcpselection.TimeBetweenBuckets: 18.831
+physics.analyzers.wcpselection.TimeBetweenBuckets: 18.936
 physics.analyzers.wcpselection.BucketTimeSigma: ${BucketTimeSigma}
 physics.analyzers.wcpselection.NBucketsPerBatch: 84
 physics.analyzers.wcpselection.NFilledBucketsPerBatch: 81

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ccpi0_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ccpi0_overlay.sh
@@ -49,7 +49,7 @@ if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the 
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
-	BucketTimeSigma="2.5"
+	BucketTimeSigma="2.8"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ccpi0_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ccpi0_overlay_detvar.sh
@@ -49,7 +49,7 @@ if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the 
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
-	BucketTimeSigma='2.5'
+	BucketTimeSigma='2.8'
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ccpi0_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ccpi0_overlay_detvar.sh
@@ -135,7 +135,7 @@ physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
 
 physics.analyzers.wcpselection.get_reboone_time:     ${flag_reboone}
-physics.analyzers.wcpselection.TimeBetweenBuckets: 18.831
+physics.analyzers.wcpselection.TimeBetweenBuckets: 18.936
 physics.analyzers.wcpselection.BucketTimeSigma: ${BucketTimeSigma}
 physics.analyzers.wcpselection.NBucketsPerBatch: 84
 physics.analyzers.wcpselection.NFilledBucketsPerBatch: 81

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_dirt_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_dirt_overlay.sh
@@ -49,7 +49,7 @@ if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the 
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
-	BucketTimeSigma='2.5'
+	BucketTimeSigma='2.8'
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_dirt_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_dirt_overlay.sh
@@ -103,7 +103,7 @@ physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
 
 physics.analyzers.wcpselection.get_reboone_time:     true
-physics.analyzers.wcpselection.TimeBetweenBuckets: 18.831
+physics.analyzers.wcpselection.TimeBetweenBuckets: 18.936
 physics.analyzers.wcpselection.BucketTimeSigma: ${BucketTimeSigma}
 physics.analyzers.wcpselection.NBucketsPerBatch: 84
 physics.analyzers.wcpselection.NFilledBucketsPerBatch: 81

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_fullosc_numu2nue_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_fullosc_numu2nue_overlay.sh
@@ -49,7 +49,7 @@ if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the 
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
-	BucketTimeSigma='2.5'
+	BucketTimeSigma='2.8'
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_fullosc_numu2nue_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_fullosc_numu2nue_overlay.sh
@@ -103,7 +103,7 @@ physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
 
 physics.analyzers.wcpselection.get_reboone_time:     true
-physics.analyzers.wcpselection.TimeBetweenBuckets: 18.831
+physics.analyzers.wcpselection.TimeBetweenBuckets: 18.936
 physics.analyzers.wcpselection.BucketTimeSigma: ${BucketTimeSigma}
 physics.analyzers.wcpselection.NBucketsPerBatch: 84
 physics.analyzers.wcpselection.NFilledBucketsPerBatch: 81

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_intrinsic_nue_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_intrinsic_nue_overlay.sh
@@ -103,7 +103,7 @@ physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
 
 physics.analyzers.wcpselection.get_reboone_time:     true
-physics.analyzers.wcpselection.TimeBetweenBuckets: 18.831
+physics.analyzers.wcpselection.TimeBetweenBuckets: 18.936
 physics.analyzers.wcpselection.BucketTimeSigma: ${BucketTimeSigma}
 physics.analyzers.wcpselection.NBucketsPerBatch: 84
 physics.analyzers.wcpselection.NFilledBucketsPerBatch: 81

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_intrinsic_nue_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_intrinsic_nue_overlay.sh
@@ -49,7 +49,7 @@ if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the 
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
-        BucketTimeSigma="2.5"
+        BucketTimeSigma="2.8"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_intrinsic_nue_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_intrinsic_nue_overlay_detvar.sh
@@ -49,7 +49,7 @@ if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the 
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
-	BucketTimeSigma="2.5"
+	BucketTimeSigma="2.8"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_intrinsic_nue_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_intrinsic_nue_overlay_detvar.sh
@@ -135,7 +135,7 @@ physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
 
 physics.analyzers.wcpselection.get_reboone_time:     ${flag_reboone}
-physics.analyzers.wcpselection.TimeBetweenBuckets: 18.831
+physics.analyzers.wcpselection.TimeBetweenBuckets: 18.936
 physics.analyzers.wcpselection.BucketTimeSigma: ${BucketTimeSigma}
 physics.analyzers.wcpselection.NBucketsPerBatch: 84
 physics.analyzers.wcpselection.NFilledBucketsPerBatch: 81

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncdelta_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncdelta_overlay.sh
@@ -49,7 +49,7 @@ if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the 
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
-	BucketTimeSigma='2.5'
+	BucketTimeSigma='2.8'
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncdelta_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncdelta_overlay.sh
@@ -103,7 +103,7 @@ physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
 
 physics.analyzers.wcpselection.get_reboone_time:     true
-physics.analyzers.wcpselection.TimeBetweenBuckets: 18.831
+physics.analyzers.wcpselection.TimeBetweenBuckets: 18.936
 physics.analyzers.wcpselection.BucketTimeSigma: ${BucketTimeSigma}
 physics.analyzers.wcpselection.NBucketsPerBatch: 84
 physics.analyzers.wcpselection.NFilledBucketsPerBatch: 81

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncdelta_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncdelta_overlay_detvar.sh
@@ -49,7 +49,7 @@ if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the 
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
-	BucketTimeSigma='2.5'
+	BucketTimeSigma='2.8'
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncdelta_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncdelta_overlay_detvar.sh
@@ -135,7 +135,7 @@ physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
 
 physics.analyzers.wcpselection.get_reboone_time:     ${flag_reboone}
-physics.analyzers.wcpselection.TimeBetweenBuckets: 18.831
+physics.analyzers.wcpselection.TimeBetweenBuckets: 18.936
 physics.analyzers.wcpselection.BucketTimeSigma: ${BucketTimeSigma}
 physics.analyzers.wcpselection.NBucketsPerBatch: 84
 physics.analyzers.wcpselection.NFilledBucketsPerBatch: 81

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncpi0_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncpi0_overlay.sh
@@ -49,7 +49,7 @@ if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the 
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
-	BucketTimeSigma='2.5'
+	BucketTimeSigma='2.8'
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncpi0_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncpi0_overlay.sh
@@ -103,7 +103,7 @@ physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
 
 physics.analyzers.wcpselection.get_reboone_time:     true
-physics.analyzers.wcpselection.TimeBetweenBuckets: 18.831
+physics.analyzers.wcpselection.TimeBetweenBuckets: 18.936
 physics.analyzers.wcpselection.BucketTimeSigma: ${BucketTimeSigma}
 physics.analyzers.wcpselection.NBucketsPerBatch: 84
 physics.analyzers.wcpselection.NFilledBucketsPerBatch: 81

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncpi0_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncpi0_overlay_detvar.sh
@@ -49,7 +49,7 @@ if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the 
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
-	BucketTimeSigma='2.5'
+	BucketTimeSigma='2.8'
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncpi0_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_ncpi0_overlay_detvar.sh
@@ -135,7 +135,7 @@ physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
 
 physics.analyzers.wcpselection.get_reboone_time:     ${flag_reboone}
-physics.analyzers.wcpselection.TimeBetweenBuckets: 18.831
+physics.analyzers.wcpselection.TimeBetweenBuckets: 18.936
 physics.analyzers.wcpselection.BucketTimeSigma: ${BucketTimeSigma}
 physics.analyzers.wcpselection.NBucketsPerBatch: 84
 physics.analyzers.wcpselection.NFilledBucketsPerBatch: 81

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_nu_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_nu_overlay.sh
@@ -103,7 +103,7 @@ physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
 
 physics.analyzers.wcpselection.get_reboone_time:     true
-physics.analyzers.wcpselection.TimeBetweenBuckets: 18.831
+physics.analyzers.wcpselection.TimeBetweenBuckets: 18.936
 physics.analyzers.wcpselection.BucketTimeSigma: ${BucketTimeSigma}
 physics.analyzers.wcpselection.NBucketsPerBatch: 84
 physics.analyzers.wcpselection.NFilledBucketsPerBatch: 81

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_nu_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_nu_overlay.sh
@@ -49,7 +49,7 @@ if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the 
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
-        BucketTimeSigma="2.5"
+        BucketTimeSigma="2.8"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_nu_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_nu_overlay_detvar.sh
@@ -49,7 +49,7 @@ if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the 
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
-	BucketTimeSigma="2.5"
+	BucketTimeSigma="2.8"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_nu_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_nu_overlay_detvar.sh
@@ -135,7 +135,7 @@ physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
 
 physics.analyzers.wcpselection.get_reboone_time:     ${flag_reboone}
-physics.analyzers.wcpselection.TimeBetweenBuckets: 18.831
+physics.analyzers.wcpselection.TimeBetweenBuckets: 18.936
 physics.analyzers.wcpselection.BucketTimeSigma: ${BucketTimeSigma}
 physics.analyzers.wcpselection.NBucketsPerBatch: 84
 physics.analyzers.wcpselection.NFilledBucketsPerBatch: 81

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_single_photon_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_single_photon_overlay.sh
@@ -49,7 +49,7 @@ if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the 
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
-        BucketTimeSigma='2.5'
+        BucketTimeSigma='2.8'
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_single_photon_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_single_photon_overlay.sh
@@ -103,7 +103,7 @@ physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
 
 physics.analyzers.wcpselection.get_reboone_time:     true
-physics.analyzers.wcpselection.TimeBetweenBuckets: 18.831
+physics.analyzers.wcpselection.TimeBetweenBuckets: 18.936
 physics.analyzers.wcpselection.BucketTimeSigma: ${BucketTimeSigma}
 physics.analyzers.wcpselection.NBucketsPerBatch: 84
 physics.analyzers.wcpselection.NFilledBucketsPerBatch: 81

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_single_photon_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_single_photon_overlay_detvar.sh
@@ -49,7 +49,7 @@ if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the 
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
-	BucketTimeSigma='2.5'
+	BucketTimeSigma='2.8'
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_single_photon_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_bnb_single_photon_overlay_detvar.sh
@@ -135,7 +135,7 @@ physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
 
 physics.analyzers.wcpselection.get_reboone_time:     ${flag_reboone}
-physics.analyzers.wcpselection.TimeBetweenBuckets: 18.831
+physics.analyzers.wcpselection.TimeBetweenBuckets: 18.936
 physics.analyzers.wcpselection.BucketTimeSigma: ${BucketTimeSigma}
 physics.analyzers.wcpselection.NBucketsPerBatch: 84
 physics.analyzers.wcpselection.NFilledBucketsPerBatch: 81

--- a/ubana/MicroBooNEWireCell/utils/fully_unified_reco2_wirecell.sh
+++ b/ubana/MicroBooNEWireCell/utils/fully_unified_reco2_wirecell.sh
@@ -15,6 +15,7 @@ wc_input_celltree=""
 isOVERLAY=0
 data_type="DATA"
 isNuMI=0
+image_fail_check=1
 
 if ls celltreeDATA*.root 1> /dev/null 2>&1; then
         wc_input_celltree=`ls celltreeDATA*.root | xargs | awk '{print $1}'`
@@ -25,6 +26,7 @@ elif ls celltreeOVERLAY*.root 1> /dev/null 2>&1; then
         wc_input_celltree=`ls celltreeOVERLAY*.root | xargs | awk '{print $1}'`
       	isOVERLAY=1
 	data_type='OVERLAY'
+        image_fail_check=2 #needed to recover the truth info for these events 
         if ls *numi*.fcl 1> /dev/null 2>&1; then
                 isNuMI=1
         fi
@@ -85,7 +87,7 @@ do
 		input2=${input1#*result_}
 		echo $input2 | tee -a ../wirecell.log
 		mv $imagingfile imaging_$input2.root
-		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -y1 -d$isOVERLAY 2>&1 | tee -a ../wirecell.log
+		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -y$image_fail_check -d$isOVERLAY 2>&1 | tee -a ../wirecell.log
 		warning=`tail -n 1 ../wirecell.log`
 		echo "$warning"
 		if [ "$warning" = "No points! Quit! " ]; then

--- a/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_overlay.sh
@@ -64,7 +64,7 @@ do
 		input2=${input1#*result_}
 		echo $input2 | tee -a ../wirecell.log
 		mv $imagingfile imaging_$input2.root
-		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -y1 -d1 2>&1 | tee -a ../wirecell.log
+		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -y2 -d1 2>&1 | tee -a ../wirecell.log
 		warning=`tail -n 1 ../wirecell.log`
 		echo "$warning"
 		if [ "$warning" = "No points! Quit! " ]; then

--- a/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_overlay_numi.sh
+++ b/ubana/MicroBooNEWireCell/utils/unified_reco2_wirecell_overlay_numi.sh
@@ -64,7 +64,7 @@ do
 		input2=${input1#*result_}
 		echo $input2 | tee -a ../wirecell.log
 		mv $imagingfile imaging_$input2.root
-		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -y1 -d1 2>&1 | tee -a ../wirecell.log
+		prod-wire-cell-matching-nusel ./input_data_files/ChannelWireGeometry_v2.txt imaging_$input2.root -y2 -d1 2>&1 | tee -a ../wirecell.log
 		warning=`tail -n 1 ../wirecell.log`
 		echo "$warning"
 		if [ "$warning" = "No points! Quit! " ]; then


### PR DESCRIPTION
Removing MC timing calibration as the default option in the helper scripts and fhicls. Both the stand-alone WC workflow and the super unified workflow has been updated accordingly.