### PR TITLE
add prefilt hits branches

### DIFF
--- a/ubana/searchingfornues/Selection/job/neutrinoselection.fcl
+++ b/ubana/searchingfornues/Selection/job/neutrinoselection.fcl
@@ -249,6 +249,8 @@ SlicePurComplTool: {
     HTproducer: "gaushitTruthMatch"
     OrigHproducer: "gaushit::OverlayStage1a"
     OrigHTproducer: "gaushitTruthMatch::OverlayRecoStage1b"
+    PreFiltHproducer: "nuslhits"
+    PreFiltHTproducer: "nuslhits"
 }
 
 NuGraphCountsTool: {


### PR DESCRIPTION
This PR adds branches to keep track of the hit collection before the NuGraph filter, thus allowing to study in detail how the filter performs