### PR TITLE
Add a reduced gLEE ntuple to super unified ntuples 

### DIFF
--- a/ubana/CombinedReco/CMakeLists.txt
+++ b/ubana/CombinedReco/CMakeLists.txt
@@ -1,3 +1,3 @@
-install_fhicl() 
+install_fhicl()
 FILE(GLOB fcl_files *.fcl)
 install_source( EXTRAS ${fcl_files} )

--- a/ubana/CombinedReco/CMakeLists.txt
+++ b/ubana/CombinedReco/CMakeLists.txt
@@ -1,3 +1,3 @@
-install_fhicl()
+install_fhicl() 
 FILE(GLOB fcl_files *.fcl)
 install_source( EXTRAS ${fcl_files} )

--- a/ubana/CombinedReco/run_combinedrecotree.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree.fcl
@@ -1,9 +1,10 @@
+#include "microboone_singlephoton.fcl"
 #include "time_memory_tracker_microboone.fcl"
 #include "services_microboone.fcl"
 #include "database_microboone.fcl"
 #include "databaseutil_microboone.fcl"
 #include "neutrinoselection.fcl"
-process_name: CombinedRecoAnaTree
+process_name: CombinedRecoAnaTree2
 
 services:
 {
@@ -57,10 +58,13 @@ physics:
         pandoraTrackpid:                  @local::particleidconfig
         pandoraTrackcali:                 @local::microboone_reco_data_producers.pandoracaliSCE
         pandoraTrackcalipid:              @local::particleidconfig
+        allShr:                           @local::microboone_pandoraShowerCreation
+
   }
   filters:
   {
-        nuselection: @local::NuSelectionFilterEmpty
+        nuselection: @local::NuSelectionFilterEmpty 
+        singlephotonana: @local::singlephoton_analyzer  
   }
   analyzers:
   {
@@ -103,7 +107,7 @@ physics:
       MCS:          true      
       
       # LANTERN integration options
-      RunLArPID:          true
+      RunLArPID:          false
       LArPIDModel:        "LArPID_default_network_weights_torchscript_v2_model.pt"
       PixelThreshold:     5
       AllPlaneThreshold:  true
@@ -225,7 +229,7 @@ physics:
   # ana: [ wcpselection, wcpweights ]
   ana: [ wcpselection ]
 
-  p1: [ nuslicehits, proximity, shrreco3d, shrreco3dKalmanShower, shrreco3dKalmanShowercalo, shrreco3dKalmanShowercali, pandoraTrack, pandoraTrackcalo, pandoraTrackpid, pandoraTrackcali, pandoraTrackcalipid, nuselection]
+  p1: [ nuslicehits, proximity, shrreco3d, shrreco3dKalmanShower, shrreco3dKalmanShowercalo, shrreco3dKalmanShowercali, pandoraTrack, pandoraTrackcalo, pandoraTrackpid, pandoraTrackcali, pandoraTrackcalipid, nuselection ,allShr, singlephotonana]
 
   e1: [ rootout ]
   ## trigger_paths contains the paths that modify the art::Event
@@ -307,6 +311,11 @@ physics.producers.proximity.HitProducer: "nuslicehits"
 
 physics.producers.pandoraTrackcali.ELifetimeCorrection: true
 physics.producers.shrreco3dKalmanShowercali.ELifetimeCorrection: true
+
+
+physics.producers.allShr.PFParticleLabel: "pandoraPatRec:allOutcomes"
+physics.filters.singlephotonana.TruncMeanFraction: 10.0
+services.DetectorClocksService.TrigModuleName:               "daq"
 
 microboone_tfile_metadata:
 {

--- a/ubana/CombinedReco/run_combinedrecotree.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree.fcl
@@ -4,7 +4,7 @@
 #include "database_microboone.fcl"
 #include "databaseutil_microboone.fcl"
 #include "neutrinoselection.fcl"
-process_name: CombinedRecoAnaTree2
+process_name: CombinedRecoAnaTree
 
 services:
 {
@@ -59,7 +59,6 @@ physics:
         pandoraTrackcali:                 @local::microboone_reco_data_producers.pandoracaliSCE
         pandoraTrackcalipid:              @local::particleidconfig
         allShr:                           @local::microboone_pandoraShowerCreation
-
   }
   filters:
   {
@@ -107,7 +106,7 @@ physics:
       MCS:          true      
       
       # LANTERN integration options
-      RunLArPID:          false
+      RunLArPID:          true
       LArPIDModel:        "LArPID_default_network_weights_torchscript_v2_model.pt"
       PixelThreshold:     5
       AllPlaneThreshold:  true
@@ -312,10 +311,7 @@ physics.producers.proximity.HitProducer: "nuslicehits"
 physics.producers.pandoraTrackcali.ELifetimeCorrection: true
 physics.producers.shrreco3dKalmanShowercali.ELifetimeCorrection: true
 
-
 physics.producers.allShr.PFParticleLabel: "pandoraPatRec:allOutcomes"
-physics.filters.singlephotonana.TruncMeanFraction: 10.0
-services.DetectorClocksService.TrigModuleName:               "daq"
 
 microboone_tfile_metadata:
 {

--- a/ubana/CombinedReco/run_combinedrecotree.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree.fcl
@@ -311,7 +311,7 @@ physics.producers.proximity.HitProducer: "nuslicehits"
 physics.producers.pandoraTrackcali.ELifetimeCorrection: true
 physics.producers.shrreco3dKalmanShowercali.ELifetimeCorrection: true
 
-physics.producers.allShr.PFParticleLabel: "pandoraPatRec:allOutcomes"
+physics.producers.allShr.PFParticleLabel: "pandoraPatRecInit:allOutcomes"
 
 microboone_tfile_metadata:
 {

--- a/ubana/CombinedReco/run_combinedrecotree.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree.fcl
@@ -229,7 +229,7 @@ physics:
   # ana: [ wcpselection, wcpweights ]
   ana: [ wcpselection ]
 
-  p1: [ nuslicehits, proximity, shrreco3d, shrreco3dKalmanShower, shrreco3dKalmanShowercalo, shrreco3dKalmanShowercali, pandoraTrack, pandoraTrackcalo, pandoraTrackpid, pandoraTrackcali, pandoraTrackcalipid, nuselection ,allShr, singlephotonana]
+  p1: [ nuslicehits, proximity, shrreco3d, shrreco3dKalmanShower, shrreco3dKalmanShowercalo, shrreco3dKalmanShowercali, pandoraTrack, pandoraTrackcalo, pandoraTrackpid, pandoraTrackcali, pandoraTrackcalipid, allShr, singlephotonana, nuselection ]
 
   e1: [ rootout ]
   ## trigger_paths contains the paths that modify the art::Event

--- a/ubana/CombinedReco/run_combinedrecotree_overlay.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree_overlay.fcl
@@ -37,4 +37,10 @@ physics.analyzers.wcpselection.POT_inputTag:	"generator"
 physics.analyzers.wcpweights.SaveWeights:	true
 physics.analyzers.wcpweights.SaveFullWeights:	true
 
+physics.filters.singlephotonana.isData: "false"
+physics.filters.singlephotonana.BadChannelProducer: "nfspl1"
+physics.filters.singlephotonana.isOverlayed: "true"
+physics.filters.singlephotonana.beamgateStartTime: 3.57
+physics.filters.singlephotonana.beamgateEndTime: 5.25
+
 physics.ana: [wcpselection, wcpweights]

--- a/ubana/CombinedReco/run_combinedrecotree_run1_data.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree_run1_data.fcl
@@ -44,6 +44,12 @@ physics.producers.pandoraTrackcalipid.Chi2PIDAlg.UseMedian:                     
 physics.producers.proximity.VtxProducer: "pandora"
 physics.producers.proximity.HitProducer: "nuslicehits"
 
+###### SinglePhoton gLEE #####
+physics.filters.singlephotonana.isData: "true"
+physics.filters.singlephotonana.POTLabel: "beamdata"
+physics.filters.singlephotonana.beamgateStartTime: 3.19
+physics.filters.singlephotonana.beamgateEndTime: 4.87
+physics.filters.singlephotonana.BadChannelProducer: "nfspl1"
 
 microboone_tfile_metadata: {
    GenerateTFileMetadata: true

--- a/ubana/SinglePhotonAnalysis/SinglePhoton_module.cc
+++ b/ubana/SinglePhotonAnalysis/SinglePhoton_module.cc
@@ -1527,7 +1527,7 @@ namespace single_photon
 
         if (m_fill_trees &&  (  (filter_pass_2g1p && m_run_pi0_filter_2g1p) || (filter_pass_2g0p && m_run_pi0_filter_2g0p) || !m_run_pi0_filter ) ) {
             vertex_tree->Fill();
-            ncdelta_slice_tree->Fill();
+            //ncdelta_slice_tree->Fill();
             eventweight_tree->Fill();
             true_eventweight_tree->Fill();
             geant4_tree->Fill();
@@ -1567,7 +1567,7 @@ namespace single_photon
         vertex_tree = tfs->make<TTree>("vertex_tree", "vertex_tree");
         pot_tree = tfs->make<TTree>("pot_tree", "pot_tree");
         eventweight_tree = tfs->make<TTree>("eventweight_tree", "eventweight_tree");
-        ncdelta_slice_tree = tfs->make<TTree>("ncdelta_slice_tree", "ncdelta_slice_tree");
+        //ncdelta_slice_tree = tfs->make<TTree>("ncdelta_slice_tree", "ncdelta_slice_tree");
         run_subrun_tree = tfs->make<TTree>("run_subrun_tree","run_subrun_tree");
         geant4_tree = tfs->make<TTree>("geant4_tree","geant4_tree");
 

--- a/ubana/SinglePhotonAnalysis/SinglePhoton_module.cc
+++ b/ubana/SinglePhotonAnalysis/SinglePhoton_module.cc
@@ -1567,7 +1567,7 @@ namespace single_photon
         vertex_tree = tfs->make<TTree>("vertex_tree", "vertex_tree");
         pot_tree = tfs->make<TTree>("pot_tree", "pot_tree");
         eventweight_tree = tfs->make<TTree>("eventweight_tree", "eventweight_tree");
-        //ncdelta_slice_tree = tfs->make<TTree>("ncdelta_slice_tree", "ncdelta_slice_tree");
+        ncdelta_slice_tree = tfs->make<TTree>("ncdelta_slice_tree", "ncdelta_slice_tree");
         run_subrun_tree = tfs->make<TTree>("run_subrun_tree","run_subrun_tree");
         geant4_tree = tfs->make<TTree>("geant4_tree","geant4_tree");
 

--- a/ubana/SinglePhotonAnalysis/SinglePhoton_module.h
+++ b/ubana/SinglePhotonAnalysis/SinglePhoton_module.h
@@ -1781,6 +1781,9 @@ namespace single_photon
             double m_mctruth_nu_vertex_x;
             double m_mctruth_nu_vertex_y;
             double m_mctruth_nu_vertex_z;
+            double m_mctruth_nu_vertex_x_nonsce;
+            double m_mctruth_nu_vertex_y_nonsce;
+            double m_mctruth_nu_vertex_z_nonsce;
             double m_mctruth_reco_vertex_dist;
             double m_mctruth_lepton_E;
             int m_mctruth_nu_pdg;

--- a/ubana/SinglePhotonAnalysis/analyze_MCTruth.h
+++ b/ubana/SinglePhotonAnalysis/analyze_MCTruth.h
@@ -11,6 +11,9 @@ namespace single_photon
         m_mctruth_nu_vertex_y = -9999;
         m_mctruth_nu_vertex_z = -9999;
         m_mctruth_reco_vertex_dist = -9999;
+        m_mctruth_nu_vertex_x_nonsce = -9999;
+        m_mctruth_nu_vertex_y_nonsce = -9999;
+        m_mctruth_nu_vertex_z_nonsce = -9999;
         m_mctruth_ccnc = -99;
         m_mctruth_qsqr = -99;
         m_mctruth_nu_E = -99;
@@ -140,6 +143,11 @@ namespace single_photon
         vertex_tree->Branch("mctruth_nu_vertex_x",&m_mctruth_nu_vertex_x);
         vertex_tree->Branch("mctruth_nu_vertex_y",&m_mctruth_nu_vertex_y);
         vertex_tree->Branch("mctruth_nu_vertex_z",&m_mctruth_nu_vertex_z);
+        vertex_tree->Branch("mctruth_nu_vertex_x_nonsce",&m_mctruth_nu_vertex_x_nonsce);
+        vertex_tree->Branch("mctruth_nu_vertex_y_nonsce",&m_mctruth_nu_vertex_y_nonsce);
+        vertex_tree->Branch("mctruth_nu_vertex_z_nonsce",&m_mctruth_nu_vertex_z_nonsce);
+
+
         vertex_tree->Branch("mctruth_reco_vertex_dist",&m_mctruth_reco_vertex_dist);
 
         vertex_tree->Branch("mctruth_lepton_pdg",&m_mctruth_lepton_pdg);
@@ -281,13 +289,19 @@ namespace single_photon
                 if(m_is_verbose) std::cout<<"Getting SC corrected vertex position"<<std::endl;
                 std::vector<double> corrected(3);
 	        // get corrected lepton position
-                this->spacecharge_correction( truth->GetNeutrino().Lepton(),corrected);
+            
+                this->spacecharge_correction(truth->GetNeutrino().Lepton(),corrected);
 
                 m_mctruth_nu_vertex_x = corrected[0];
                 m_mctruth_nu_vertex_y = corrected[1];
                 m_mctruth_nu_vertex_z = corrected[2];
                 m_mctruth_reco_vertex_dist = sqrt(pow (m_mctruth_nu_vertex_x-m_vertex_pos_x,2)+pow (m_mctruth_nu_vertex_y-m_vertex_pos_y,2)+pow (m_mctruth_nu_vertex_z-m_vertex_pos_z,2));
-            
+           
+                m_mctruth_nu_vertex_x_nonsce = truth->GetNeutrino().Lepton().Vx();
+                m_mctruth_nu_vertex_y_nonsce = truth->GetNeutrino().Lepton().Vy();
+                m_mctruth_nu_vertex_z_nonsce = truth->GetNeutrino().Lepton().Vz();
+
+
             }
 
 
@@ -329,7 +343,26 @@ namespace single_photon
                 m_mctruth_daughters_process[j] = par.Process();  //Process() and EndProcess() return string
                 m_mctruth_daughters_end_process[j] = par.EndProcess();
 
-                if(m_is_textgen) continue; //quick hack, fix in files
+                if(m_is_textgen){
+                    //If its textgen, the corrected mctruth_nu_vertex will fail. Fill here from the daughters
+    
+                    if(m_mctruth_nu_vertex_x < -999){
+                        std::vector<double> corrected(3);
+                        this->spacecharge_correction(par,corrected);
+                        m_mctruth_nu_vertex_x = corrected[0];
+                        m_mctruth_nu_vertex_y = corrected[1];
+                        m_mctruth_nu_vertex_z = corrected[2];
+                        m_mctruth_reco_vertex_dist = sqrt(pow (m_mctruth_nu_vertex_x-m_vertex_pos_x,2)+pow (m_mctruth_nu_vertex_y-m_vertex_pos_y,2)+pow (m_mctruth_nu_vertex_z-m_vertex_pos_z,2));
+                   
+                        m_mctruth_nu_vertex_x_nonsce = par.Vx();
+                        m_mctruth_nu_vertex_y_nonsce = par.Vy();
+                        m_mctruth_nu_vertex_z_nonsce = par.Vz();
+
+
+                    }            
+                    
+                continue; //quick hack, fix in files
+                }
 
                 switch(m_mctruth_daughters_pdg[j]){
                     case(22): // if it's a gamma

--- a/ubana/SinglePhotonAnalysis/job/microboone_singlephoton.fcl
+++ b/ubana/SinglePhotonAnalysis/job/microboone_singlephoton.fcl
@@ -36,7 +36,7 @@ singlephoton_analyzer:{
     SEAviewStubMakePDF: false 
     SEAviewStubNumRecoShower: 1
     SEAviewStubNumRecoTrack: 0
-
+    
     FillTrees: true
     RunPi0Filter: false
     FilterMode2g1p: false
@@ -53,7 +53,8 @@ singlephoton_analyzer:{
     wire_spacing : 0.3 
     width_box : 1.
     length_box : 4.
-    
+    TruncMeanFraction: 10.0
+
     truthmatching_signaldef : "ncdelta"
     runAllPFPs: "false"
     exiting_photon_energy: 0.02

--- a/ubana/SinglePhotonAnalysis/job/run_SinglePhoton_TextGen.fcl
+++ b/ubana/SinglePhotonAnalysis/job/run_SinglePhoton_TextGen.fcl
@@ -2,8 +2,12 @@
 
 services.FileCatalogMetadata:  @local::art_file_catalog_overlay    # or art_file_catalog_data, or art_file_catalog_overlay
 
-physics.filters.singlephotonana.beamgateStartTime: 3.16
-physics.filters.singlephotonana.beamgateEndTime: 4.84
-
 physics.filters.singlephotonana.isTextGen: "true"
 
+physics.filters.singlephotonana.BadChannelProducer: "nfspl1"
+physics.filters.singlephotonana.isOverlayed: "true"
+physics.filters.singlephotonana.beamgateStartTime: 3.57
+physics.filters.singlephotonana.beamgateEndTime: 5.25
+physics.filters.singlephotonana.TruncMeanFraction: 10.0
+#This is needed in order to help with wierd offset (4049.969 us)   
+services.DetectorClocksService.TrigModuleName:               "triggersim"

--- a/ubana/SinglePhotonAnalysis/job/run_SinglePhoton_TextGen_MC.fcl
+++ b/ubana/SinglePhotonAnalysis/job/run_SinglePhoton_TextGen_MC.fcl
@@ -1,0 +1,9 @@
+#include "run_SinglePhoton.fcl"
+
+services.FileCatalogMetadata:  @local::art_file_catalog_overlay    # or art_file_catalog_data, or art_file_catalog_overlay
+
+physics.filters.singlephotonana.isTextGen: "true"
+
+physics.filters.singlephotonana.BadChannelProducer: "nfspl1"
+physics.filters.singlephotonana.beamgateStartTime: 3.16
+physics.filters.singlephotonana.beamgateEndTime: 4.84


### PR DESCRIPTION
Added the gLEE ntuple maker to the super unified fcl workflow. A reduced ntuple is made without any eventweight or CRT information, but includes necessary info for gLEE BDT's (including SSv and PSV stub based analysis of pandora unassociated hits). 
Includes also a minor tweak to how the mctruth vertex was saved in ntuples to match with the issue as fixed in standalone gLEE. 