### PR TITLE
Pandora ns timing upgrades

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 find_package(cetmodules REQUIRED)
-project(ubana VERSION 10.04.07.01 LANGUAGES CXX)
+project(ubana VERSION 10.04.08 LANGUAGES CXX)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 find_package(cetmodules REQUIRED)
-project(ubana VERSION 10.04.07.02 LANGUAGES CXX)
+project(ubana VERSION 10.04.07.01 LANGUAGES CXX)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/ubana/searchingfornues/Selection/job/neutrinoselection.fcl
+++ b/ubana/searchingfornues/Selection/job/neutrinoselection.fcl
@@ -362,7 +362,7 @@ NuSelectionFilter:{
         default: @local::DefaultAnalysisTool
         # you can add more analysis tools here
         slicepurcompl: @local::SlicePurComplTool
-        nugraphcounts: @local::NuGraphCountsTool
+        #nugraphcounts: @local::NuGraphCountsTool
         containment:   @local::ContainmentAnalysis
         #shower:        @local::ShowerAnalysisTool
         #showerstart:        @local::ShowerStartPointTool
@@ -380,7 +380,7 @@ NuSelectionFilter:{
         secondshower:  @local::SecondShowerTaggerTool
         eventfilter:   @local::EventFilterTool
         mcfilter:      @local::MCFilterAnalysisTool
-        blip:          @local::BlipAnalysisTool
+        #blip:          @local::BlipAnalysisTool
         #neutron:       @local::NeutronAnalysisTool
         timing:        @local::NeutrinoTimingAnalysisTool
     }

--- a/ubana/searchingfornues/Selection/job/numi/run_neutrinoselectionfilter_run4_dataOFF_cc0pinp_numi.fcl
+++ b/ubana/searchingfornues/Selection/job/numi/run_neutrinoselectionfilter_run4_dataOFF_cc0pinp_numi.fcl
@@ -1,6 +1,7 @@
-#include "run_neutrinoselectionfilter_run3_dataON_cc0pinp.fcl"
+#include "run_neutrinoselectionfilter_run3_dataON_cc0pinp_numi.fcl"
 
 physics.filters.nuselection.AnalysisTools.flashmatchid.ApplyLifetimeCorr: true
 
+physics.filters.nuselection.AnalysisTools.timing.isNuMI: true
 physics.filters.nuselection.AnalysisTools.timing.isEXT: true
 physics.filters.nuselection.AnalysisTools.timing.isMC: false

--- a/ubana/searchingfornues/Selection/job/numi/run_neutrinoselectionfilter_run4_dataON_cc0pinp_numi.fcl
+++ b/ubana/searchingfornues/Selection/job/numi/run_neutrinoselectionfilter_run4_dataON_cc0pinp_numi.fcl
@@ -1,3 +1,5 @@
 #include "run_neutrinoselectionfilter_run3_dataON_cc0pinp_numi.fcl"
 
 physics.filters.nuselection.AnalysisTools.flashmatchid.ApplyLifetimeCorr: true
+
+physics.filters.nuselection.AnalysisTools.timing.isNuMI: true

--- a/ubana/searchingfornues/Selection/job/numi/run_neutrinoselectionfilter_run4_overlay_cc0pinp_numi.fcl
+++ b/ubana/searchingfornues/Selection/job/numi/run_neutrinoselectionfilter_run4_overlay_cc0pinp_numi.fcl
@@ -1,3 +1,10 @@
 #include "run_neutrinoselectionfilter_run3_overlay_cc0pinp_numi.fcl"
 
 physics.filters.nuselection.AnalysisTools.flashmatchid.ApplyLifetimeCorr: true
+
+#nstiming
+physics.filters.nuselection.AnalysisTools.timing.isNuMI: true
+physics.filters.nuselection.AnalysisTools.timing.isRun3: true
+physics.filters.nuselection.AnalysisTools.timing.isMC: true
+physics.filters.nuselection.AnalysisTools.timing.MCOffset: 1754
+physics.filters.nuselection.AnalysisTools.timing.SaveExtraInfo: true

--- a/ubana/searchingfornues/Selection/job/run_neutrinoselectionfilter_run4_dataON_cc0pinp.fcl
+++ b/ubana/searchingfornues/Selection/job/run_neutrinoselectionfilter_run4_dataON_cc0pinp.fcl
@@ -1,3 +1,7 @@
 #include "run_neutrinoselectionfilter_run3_dataON_cc0pinp.fcl"
 
 physics.filters.nuselection.AnalysisTools.flashmatchid.ApplyLifetimeCorr: true
+
+
+physics.filters.nuselection.AnalysisTools.timing.isEXT: false
+

--- a/ubana/searchingfornues/Selection/job/run_neutrinoselectionfilter_run4_overlay_cc0pinp.fcl
+++ b/ubana/searchingfornues/Selection/job/run_neutrinoselectionfilter_run4_overlay_cc0pinp.fcl
@@ -1,3 +1,5 @@
 #include "run_neutrinoselectionfilter_run3_overlay_cc0pinp.fcl"
 
 physics.filters.nuselection.AnalysisTools.flashmatchid.ApplyLifetimeCorr: true
+
+physics.filters.nuselection.AnalysisTools.timing.MCOffset: 1567

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -248,11 +248,11 @@ fwdir	product_dir	scripts
 #
 ####################################
 product		version		qual	flags		<table_format=2>
-larana		v10_00_13	-
-larpandora	v10_00_16	-
-ubraw		v10_04_05	-
-ubreco		v10_04_07_01	-
-ubcv            v10_04_07_01	-
+larana		v10_00_14	-
+larpandora	v10_00_17	-
+ubraw		v10_04_08	-
+ubreco		v10_04_08	-
+ubcv            v10_04_08	-
 cetmodules	v3_24_01	-	only_for_build
 end_product_list
 ####################################


### PR DESCRIPTION
This PR fixes an issue with offsets in BNB and NuMI overlay ns timing. 
Fhicl files for beam off processing are also added, allowing to ignore RWM extraction. 
More information is saved in the final ntuples to enable re-derivation of the timing without re-producing the ntuples. 