### PR TITLE
Bnb double pmt filter fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 find_package(cetmodules REQUIRED)
-project(ubana VERSION 10.05.00 LANGUAGES CXX)
+project(ubana VERSION 10.06.00 LANGUAGES CXX)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 find_package(cetmodules REQUIRED)
-project(ubana VERSION 10.04.07.05 LANGUAGES CXX)
+project(ubana VERSION 10.05.00 LANGUAGES CXX)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/ubana/CombinedReco/run_combinedrecotree_run1_overlay_numi.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree_run1_overlay_numi.fcl
@@ -34,6 +34,7 @@ physics.filters.nuselection.AnalysisTools.zbdt.TrigResProducer: "TriggerResults:
 
 physics.filters.nuselection.AnalysisTools.default.makeNuMINtuple: true
 physics.filters.nuselection.AnalysisTools.timing.IsNuMI: true
+physics.filters.nuselection.AnalysisTools.timing.isMC: true
 physics.filters.nuselection.AnalysisTools.timing.TimeBetweenBuckets: 18.831
 physics.filters.nuselection.AnalysisTools.timing.BucketTimeSigma: 0.750
 physics.filters.nuselection.AnalysisTools.timing.BatchIntensities: [1,1,1,1,1,1] # 6 batches

--- a/ubana/CombinedReco/run_combinedrecotree_run4_dataON.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree_run4_dataON.fcl
@@ -3,3 +3,4 @@
 physics.filters.nuselection.AnalysisTools.flashmatchid: @local::FlashMatchingTool
 physics.filters.nuselection.AnalysisTools.flashmatchid.ApplyLifetimeCorr: true
 physics.filters.nuselection.AnalysisTools.timing.isEXT: false
+physics.filters.nuselection.AnalysisTools.timing.nstimePMTWFproducer: "doublePMTFilter:OpdetBeamHighGain"

--- a/ubana/CombinedReco/run_combinedrecotree_run4_overlay.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree_run4_overlay.fcl
@@ -3,3 +3,4 @@
 physics.filters.nuselection.AnalysisTools.flashmatchid: @local::FlashMatchingTool
 physics.filters.nuselection.AnalysisTools.flashmatchid.ApplyLifetimeCorr: true
 physics.filters.nuselection.AnalysisTools.timing.MCOffset: 1567
+physics.filters.nuselection.AnalysisTools.timing.nstimePMTWFproducer: "mixer:OpdetBeamHighGain"

--- a/ubana/searchingfornues/Selection/job/run_neutrinoselectionfilter_run4_dataON_cc0pinp.fcl
+++ b/ubana/searchingfornues/Selection/job/run_neutrinoselectionfilter_run4_dataON_cc0pinp.fcl
@@ -1,7 +1,10 @@
 #include "run_neutrinoselectionfilter_run3_dataON_cc0pinp.fcl"
 
 physics.filters.nuselection.AnalysisTools.flashmatchid.ApplyLifetimeCorr: true
-
-
 physics.filters.nuselection.AnalysisTools.timing.isEXT: false
+
+physics.filters.nuselection.AnalysisTools.timing.nstimePMTWFproducer: "doublePMTFilter:OpdetBeamHighGain"
+physics.filters.nuselection.AnalysisTools.timing.SaveExtraInfo: true
+
+
 

--- a/ubana/searchingfornues/Selection/job/run_neutrinoselectionfilter_run4_overlay_cc0pinp.fcl
+++ b/ubana/searchingfornues/Selection/job/run_neutrinoselectionfilter_run4_overlay_cc0pinp.fcl
@@ -3,3 +3,4 @@
 physics.filters.nuselection.AnalysisTools.flashmatchid.ApplyLifetimeCorr: true
 
 physics.filters.nuselection.AnalysisTools.timing.MCOffset: 1567
+physics.filters.nuselection.AnalysisTools.timing.nstimePMTWFproducer: "mixer:OpdetBeamHighGain"

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -248,11 +248,11 @@ fwdir	product_dir	scripts
 #
 ####################################
 product		version		qual	flags		<table_format=2>
-larana		v10_00_13	-
-larpandora	v10_00_16	-
-ubraw		v10_04_07_05	-
-ubreco		v10_04_07_05	-
-ubcv            v10_04_07_05	-
+larana		v10_00_15	-
+larpandora	v10_00_18	-
+ubraw		v10_04_08	-
+ubreco		v10_05_00	-
+ubcv            v10_05_00	-
 cetmodules	v3_24_01	-	only_for_build
 end_product_list
 ####################################

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -248,11 +248,11 @@ fwdir	product_dir	scripts
 #
 ####################################
 product		version		qual	flags		<table_format=2>
-larana		v10_00_15	-
-larpandora	v10_00_18	-
-ubraw		v10_04_08	-
-ubreco		v10_05_00	-
-ubcv            v10_05_00	-
+larana		v10_00_16	-
+larpandora	v10_00_19	-
+ubraw		v10_06_00	-
+ubreco		v10_06_00	-
+ubcv            v10_06_00	-
 cetmodules	v3_24_01	-	only_for_build
 end_product_list
 ####################################


### PR DESCRIPTION
This PR is to enable the use of the correct double PMT filtered waveforms for BNB runs 4 & 5.
There are also a few additional changes to the extra variables saved by NeutrinoTiming_tool.