### PR TITLE
Retrieve right data products for overlay in ntuple-maker

### DIFF
--- a/ubana/CombinedReco/run_combinedrecotree_overlay.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree_overlay.fcl
@@ -21,6 +21,9 @@ physics.filters.nuselection.IsData: false
 
 physics.filters.nuselection.AnalysisTools.timing.isMC: true
 
+# By default, the data hit collection is set. Need to set this to use the overlay one:
+physics.filters.nuselection.AnalysisTools.slicepurcompl.OrigHproducer: "gaushit::OverlayStage1a"
+
 #physics.filters.nuselection.AnalysisTools.flashmatchid.FlashMatchConfig: @local::flash_neutrino_id_tool_overlay.FlashMatchConfig
 
 #physics.filters.nuselection.AnalysisTools.zbdt.TrigResProducer: "TriggerResults::OverlayFiltersPostStage2"
@@ -58,3 +61,4 @@ physics.filters.singlephotonana.beamgateStartTime: 3.57
 physics.filters.singlephotonana.beamgateEndTime: 5.25
 
 physics.ana: [wcpselection, wcpweights]
+

--- a/ubana/CombinedReco/run_combinedrecotree_run3_overlay_numi.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree_run3_overlay_numi.fcl
@@ -11,5 +11,3 @@ physics.filters.nuselection.AnalysisTools.zbdt: @local::BDTTool
 physics.filters.nuselection.SelectionTool: @local::CC0PiNpSelectionTool
 
 physics.filters.nuselection.AnalysisTools.shower:   @local::ShowerAnalysisTool
-
-physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "DataOverlayNoTPC"

--- a/ubana/CombinedReco/run_combinedrecotree_run3_overlay_numi.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree_run3_overlay_numi.fcl
@@ -12,4 +12,4 @@ physics.filters.nuselection.SelectionTool: @local::CC0PiNpSelectionTool
 
 physics.filters.nuselection.AnalysisTools.shower:   @local::ShowerAnalysisTool
 
-
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "DataOverlayNoTPC"


### PR DESCRIPTION
In combined ntuples fhicl files:

- tell slice purity/completeness AnalysisTool to retrieve the right hit collection for overlay (default value inherited from upstream fhicls now corresponds to _data_)

- set NuMISWTriggerProcName to `DataOverlayNoTPC` for Run3+

This was tested by running `run_combinedrecotree_run4_overlay_numi.fcl` on two reco2 test files generated by @LiangLiu212 for Run4b NuMI nu and nue overlay.