### PR TITLE
Fix the error with software trigger data in ntuple maker scripts

### DIFF
--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_ccpi0_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_ccpi0_overlay.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -96,6 +99,7 @@ horncur='_fhc'
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_ccpi0_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_ccpi0_overlay_detvar.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -128,6 +131,7 @@ fi
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_dirt_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_dirt_overlay.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -96,6 +99,7 @@ horncur='_fhc'
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_fullosc_numu2nue_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_fullosc_numu2nue_overlay.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -96,6 +99,7 @@ horncur='_fhc'
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_intrinsic_nue_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_intrinsic_nue_overlay.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -96,6 +99,7 @@ horncur='_fhc'
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_intrinsic_nue_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_intrinsic_nue_overlay_detvar.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -128,6 +131,7 @@ fi
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_kdar_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_kdar_overlay.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -96,6 +99,7 @@ horncur='_fhc'
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_kdar_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_kdar_overlay_detvar.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -128,6 +131,7 @@ fi
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_ncpi0_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_ncpi0_overlay.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -96,6 +99,7 @@ horncur='_fhc'
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_ncpi0_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_ncpi0_overlay_detvar.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -128,6 +131,7 @@ fi
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_nu_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_nu_overlay.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -96,6 +99,7 @@ horncur='_fhc'
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_nu_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_nu_overlay_detvar.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -128,6 +131,7 @@ fi
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_nuwro_fakedata.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_nuwro_fakedata.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -101,6 +104,7 @@ physics.analyzers.wcpselection.SaveWeights:     false
 physics.analyzers.wcpselection.POT_inputTag:    "generator"
 
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_ccpi0_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_ccpi0_overlay.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -96,6 +99,7 @@ horncur='_rhc'
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_ccpi0_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_ccpi0_overlay_detvar.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -128,6 +131,7 @@ fi
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_dirt_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_dirt_overlay.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -96,6 +99,7 @@ horncur='_rhc'
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_fullosc_numu2nue_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_fullosc_numu2nue_overlay.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -96,6 +99,7 @@ horncur='_rhc'
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_intrinsic_nue_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_intrinsic_nue_overlay.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -96,6 +99,7 @@ horncur='_rhc'
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_intrinsic_nue_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_intrinsic_nue_overlay_detvar.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -128,6 +131,7 @@ fi
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_kdar_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_kdar_overlay.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -96,6 +99,7 @@ horncur='_rhc'
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_kdar_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_kdar_overlay_detvar.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -128,6 +131,7 @@ fi
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_ncpi0_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_ncpi0_overlay.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -96,6 +99,7 @@ horncur='_rhc'
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_ncpi0_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_ncpi0_overlay_detvar.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -128,6 +131,7 @@ fi
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_nu_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_nu_overlay.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -96,6 +99,7 @@ horncur='_rhc'
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_nu_overlay_detvar.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_nu_overlay_detvar.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -128,6 +131,7 @@ fi
 cat <<EOF > $FCL
 #include "mix_wrapper.fcl"
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_nuwro_fakedata.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_nuwro_fakedata.sh
@@ -45,14 +45,17 @@ echo $run_number
 
 FT_STREAM="run1"
 
+STANDARD_OVERLAY="DataOverlayNoTPC"
 if [ "$run_number" -ge "3420"  ] && [  "8316" -ge "$run_number"  ];    # in the run1 run number interval
 then
         echo "run run1 fhicl"
         FT_STREAM="run1"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0008317"  ] && [  "0011048" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2a fhicl"
         FT_STREAM="run2"
+STANDARD_OVERLAY="DataOverlayOptical"
 elif [ "$run_number" -ge "0011049"  ] && [  "0013696" -ge "$run_number"  ];   # in the run2 run number interval
 then
         echo "run run2b fhicl"
@@ -101,6 +104,7 @@ physics.analyzers.wcpselection.SaveWeights:     false
 physics.analyzers.wcpselection.POT_inputTag:    "generator"
 
 
+physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "${STANDARD_OVERLAY}"
 physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 


### PR DESCRIPTION
After discussion with Patrick, we can confirm that we need to add
`physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "DataOverlayOptical"`
for pre-CRT run epoch, run1 and run2a, and
`physics.filters.nuselection.AnalysisTools.default.NuMISWTriggerProcName: "DataOverlayNoTPC"`
for post-CRT run epoch, run2b and later in ntuple maker to run numi overlay samples.

To streamline this, I update the `def_filetype` scripts to swap parameters automatically. 

