### PR TITLE
Adding Wire-Cell PMT Info

### DIFF
--- a/ubana/CombinedReco/run_combinedrecotree.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree.fcl
@@ -125,6 +125,9 @@ physics:
       SaveTrecchargeblobSpacePoints: true # these top three spacepoints aren't very big, making the resulting ntuple about 25% larger
       SaveTclusterSpacePoints: false # this one is especially large, making the resulting ntuple about 14x larger
       SaveTrueEDepSpacePoints: false # this one is especially large, making the resulting ntuple about 5x larger
+
+      # New WC PMT Info
+      SaveWCPMTInfo: true
       
       # nanosecond beam timing
       ShiftOffset: 0 #0 for Run 1, 387.8 for Run 3 before RWM cable change and 118.3 Run 3 after RWM cable change and Run 4

--- a/ubana/MicroBooNEWireCell/WireCellAnaTree_module.cc
+++ b/ubana/MicroBooNEWireCell/WireCellAnaTree_module.cc
@@ -2474,6 +2474,7 @@ void WireCellAnaTree::initOutput()
     fSpacepoints->Branch("TrueEDep_spacepoints_pdg", &TrueEDep_spacepoints_pdg);
   }
 
+
   if (f_savesps){
     fPFeval->Branch("reco_sps_x", &f_sps_x);
     fPFeval->Branch("reco_sps_y", &f_sps_y);
@@ -3926,8 +3927,8 @@ void WireCellAnaTree::analyze(art::Event const& e)
 		f_match_notFC_DC = false;
 		f_match_charge = -1;
 		f_match_energy = -1;
-		f_lm_cluster_length = -1;
-		f_image_fail = false;
+                f_lm_cluster_length = -1;
+                f_image_fail = false;
 	}
         for(nsm::NuSelectionContainment const& c : containment_vec) {
                 f_flash_found = c.GetFlashFound();

--- a/ubana/MicroBooNEWireCell/WireCellAnaTree_module.cc
+++ b/ubana/MicroBooNEWireCell/WireCellAnaTree_module.cc
@@ -2473,7 +2473,7 @@ void WireCellAnaTree::initOutput()
     fSpacepoints->Branch("TrueEDep_spacepoints_edep", &TrueEDep_spacepoints_edep);
     fSpacepoints->Branch("TrueEDep_spacepoints_pdg", &TrueEDep_spacepoints_pdg);
   }
-
+  
 
   if (f_savesps){
     fPFeval->Branch("reco_sps_x", &f_sps_x);

--- a/ubana/MicroBooNEWireCell/WireCellAnaTree_module.cc
+++ b/ubana/MicroBooNEWireCell/WireCellAnaTree_module.cc
@@ -3910,33 +3910,33 @@ void WireCellAnaTree::analyze(art::Event const& e)
 		std::cout<<"WARNING: >1 in-beam matched TPC activity?!" << std::endl;
 		//return;
 	}else{
-  if(containment_vec.size()<1) {
-                f_flash_found = false;
-                f_flash_found_asInt = -1;
-                f_flash_time = -1;
-                f_flash_measPe = -1;
-                f_flash_predPe = -1;
-                f_match_found = false;
-                f_match_found_asInt = -1;
-                f_match_type = -1;
-                f_match_isFC = false;
-                f_match_isTgm = false;
-                f_match_notFC_FV = false;
-                f_match_notFC_SP = false;
-                f_match_notFC_DC = false;
-                f_match_charge = -1;
-                f_match_energy = -1;
-                f_lm_cluster_length = -1;
-                f_image_fail = false;
-                }
+	if(containment_vec.size()<1) {
+		f_flash_found = false;
+		f_flash_found_asInt = -1;
+		f_flash_time = -1;
+		f_flash_measPe = -1;
+		f_flash_predPe = -1;
+		f_match_found = false;
+		f_match_found_asInt = -1;
+		f_match_type = -1;
+		f_match_isFC = false;
+		f_match_isTgm = false;
+		f_match_notFC_FV = false;
+		f_match_notFC_SP = false;
+		f_match_notFC_DC = false;
+		f_match_charge = -1;
+		f_match_energy = -1;
+		f_lm_cluster_length = -1;
+		f_image_fail = false;
+	}
         for(nsm::NuSelectionContainment const& c : containment_vec) {
                 f_flash_found = c.GetFlashFound();
-                f_flash_found_asInt = f_flash_found? 1:0;
+		f_flash_found_asInt = f_flash_found? 1:0;
                 f_flash_time = c.GetFlashTime();
                 f_flash_measPe = c.GetFlashMeasPe();
                 f_flash_predPe = c.GetFlashPredPe();
                 f_match_found = c.GetMatchFound();
-                f_match_found_asInt = f_match_found? 1:0;
+		f_match_found_asInt = f_match_found? 1:0;
                 f_match_type = c.GetMatchType();
                 f_match_isFC = c.GetIsFC();
                 f_match_isTgm = c.GetIsTGM();
@@ -3947,7 +3947,7 @@ void WireCellAnaTree::analyze(art::Event const& e)
                 f_match_energy = c.GetEnergy();
                 f_lm_cluster_length = c.GetLength();
                 f_image_fail = c.GetImageFail();
-  }
+	}
 }
 
         auto const& charge_vec = e.getProduct<std::vector<nsm::NuSelectionCharge>>(fChargeLabel);

--- a/ubana/MicroBooNEWireCell/WireCellAnaTree_module.cc
+++ b/ubana/MicroBooNEWireCell/WireCellAnaTree_module.cc
@@ -51,6 +51,7 @@
 #include "ubobj/WcpPort/NuSelectionSTM.h"
 #include "ubobj/WcpPort/NuSelectionBDT.h"
 #include "ubobj/WcpPort/NuSelectionKINE.h"
+#include "ubobj/WcpPort/WCPMTInfo.h"
 
 #include "TRandom3.h"
 #include "dk2nu/tree/dk2nu.h"
@@ -4144,7 +4145,7 @@ void WireCellAnaTree::analyze(art::Event const& e)
     f_WCPMTInfoPeMeas->clear();
     f_WCPMTInfoPeMeasErr->clear();
     
-    auto WCPMTInfo_handle = e.getValidHandle<std::vector<nsm::NuSelectionBDT::WCPMTInfo>>({"wirecellPF", "WCPMTInfo"});
+    auto WCPMTInfo_handle = e.getValidHandle<std::vector<nsm::WCPMTInfo>>({"wirecellPF", "WCPMTInfo"});
     if (!WCPMTInfo_handle->empty()) {
       auto const& wcpmtinfo = WCPMTInfo_handle->at(0);
       

--- a/ubana/MicroBooNEWireCell/WireCellAnaTree_module.cc
+++ b/ubana/MicroBooNEWireCell/WireCellAnaTree_module.cc
@@ -173,7 +173,6 @@ public:
   void save_LEEweights(art::Event const& e);
   void ReadBDTvar(nsm::NuSelectionBDT const& bdt);
   void ReadSSMBDTvar(nsm::NuSelectionBDT const& bdt);
-  void ReadWCPMTInfo(nsm::NuSelectionBDT const& bdt);
   void ReadKINEvar(nsm::NuSelectionKINE const& kine);
   void nsbeamtiming(art::Event const& e);
   void getPMTwf(art::Event const& e, double maxP[32],double timeP[32],bool Sat[32]);
@@ -3823,6 +3822,7 @@ void WireCellAnaTree::initOutput()
   }
 
   if (f_saveWCPMTInfo){
+    std::cout << "setting WCPMTInfo fBDT branches" << std::endl;
     fBDT->Branch("WCPMTInfoPePred", 		&f_WCPMTInfoPePred);
     fBDT->Branch("WCPMTInfoPeMeas", 		&f_WCPMTInfoPeMeas);
     fBDT->Branch("WCPMTInfoPeMeasErr", 	&f_WCPMTInfoPeMeasErr);
@@ -4150,22 +4150,30 @@ void WireCellAnaTree::analyze(art::Event const& e)
       
       // Copy vector data
       if (wcpmtinfo.WCPMTInfoPePred) {
+        std::cout << "pePred: ";
         for (auto const& pePred: *wcpmtinfo.WCPMTInfoPePred){
           f_WCPMTInfoPePred->push_back(pePred);
+          std::cout << pePred << ", ";
         }
+        std::cout << std::endl;
       }
       if (wcpmtinfo.WCPMTInfoPeMeas) {
+        std::cout << "peMeas: ";
         for (auto const& peMeas: *wcpmtinfo.WCPMTInfoPeMeas){
           f_WCPMTInfoPeMeas->push_back(peMeas);
+          std::cout << peMeas << ", ";
         }
+        std::cout << std::endl;
       }
       if (wcpmtinfo.WCPMTInfoPeMeasErr) {
+        std::cout << "peMeasErr: ";
         for (auto const& peMeasErr: *wcpmtinfo.WCPMTInfoPeMeasErr){
           f_WCPMTInfoPeMeasErr->push_back(peMeasErr);
+          std::cout << peMeasErr << ", ";
         }
+        std::cout << std::endl;
       }
       
-      // Copy scalar data
       f_WCPMTInfoTPCClusterID = wcpmtinfo.WCPMTInfoTPCClusterID;
       f_WCPMTInfoFlashID = wcpmtinfo.WCPMTInfoFlashID;
       f_WCPMTInfoStrength = wcpmtinfo.WCPMTInfoStrength;
@@ -4176,6 +4184,17 @@ void WireCellAnaTree::analyze(art::Event const& e)
       f_WCPMTInfoClusterLength = wcpmtinfo.WCPMTInfoClusterLength;
       f_WCPMTInfoNeutrinoType = wcpmtinfo.WCPMTInfoNeutrinoType;
       f_WCPMTInfoFlashTime = wcpmtinfo.WCPMTInfoFlashTime;
+
+      std::cout << "WCPMTInfoTPCClusterID: " << wcpmtinfo.WCPMTInfoTPCClusterID << std::endl;
+      std::cout << "WCPMTInfoFlashID: " << wcpmtinfo.WCPMTInfoFlashID << std::endl;
+      std::cout << "WCPMTInfoStrength: " << wcpmtinfo.WCPMTInfoStrength << std::endl;
+      std::cout << "WCPMTInfoEventType: " << wcpmtinfo.WCPMTInfoEventType << std::endl;
+      std::cout << "WCPMTInfoKSDistance: " << wcpmtinfo.WCPMTInfoKSDistance << std::endl;
+      std::cout << "WCPMTInfoChi2: " << wcpmtinfo.WCPMTInfoChi2 << std::endl;
+      std::cout << "WCPMTInfoNDF: " << wcpmtinfo.WCPMTInfoNDF << std::endl;
+      std::cout << "WCPMTInfoClusterLength: " << wcpmtinfo.WCPMTInfoClusterLength << std::endl;
+      std::cout << "WCPMTInfoNeutrinoType: " << wcpmtinfo.WCPMTInfoNeutrinoType << std::endl;
+      std::cout << "WCPMTInfoFlashTime: " << wcpmtinfo.WCPMTInfoFlashTime << std::endl;
     }
   }
 
@@ -4980,35 +4999,6 @@ void WireCellAnaTree::analyze(art::Event const& e)
 }
       }
 
-      if (f_saveWCPMTInfo){
-        auto bdthandle = e.getHandle<std::vector<nsm::NuSelectionBDT>>(fPFInputTag);
-        if (! bdthandle) return;
-	std::cout<<"--- NuSelectionWCPMTInfo ---"<<std::endl;
-        if(bdthandle->size()>1) {
-		std::cout<<"WARNING: >1 set of WCPMTInfo input variables" << std::endl;
-		//return;
-	        }else{
-                        for(nsm::NuSelectionBDT const& bdt : *bdthandle) {
-                                ReadWCPMTInfo(bdt);
-                                std::cout<<"WCPMTInfo input vars check: \n"<<
-                                bdt.GetWCPMTInfo().WCPMTInfoPePred<<" "<<
-                                bdt.GetWCPMTInfo().WCPMTInfoPeMeas<<" "<<
-                                bdt.GetWCPMTInfo().WCPMTInfoPeMeasErr<<" "<<
-                                bdt.GetWCPMTInfo().WCPMTInfoTPCClusterID<<" "<<
-                                bdt.GetWCPMTInfo().WCPMTInfoFlashID<<" "<<
-                                bdt.GetWCPMTInfo().WCPMTInfoStrength<<" "<<
-                                bdt.GetWCPMTInfo().WCPMTInfoEventType<<" "<<
-                                bdt.GetWCPMTInfo().WCPMTInfoKSDistance<<" "<<
-                                bdt.GetWCPMTInfo().WCPMTInfoChi2<<" "<<
-                                bdt.GetWCPMTInfo().WCPMTInfoNDF<<" "<<
-                                bdt.GetWCPMTInfo().WCPMTInfoClusterLength<<" "<<
-                                bdt.GetWCPMTInfo().WCPMTInfoNeutrinoType<<" "<<
-                                bdt.GetWCPMTInfo().WCPMTInfoFlashTime<<"\n";
-                        }
-                }
-
-      }
-
       if(f_KINEvars){
         auto kinehandle = e.getHandle<std::vector<nsm::NuSelectionKINE>>(fPFInputTag);
         if (! kinehandle) return;
@@ -5137,6 +5127,7 @@ void WireCellAnaTree::ProtonID(int trackId)
 
 void WireCellAnaTree::resetOutput()
 {
+        std::cout << "resetting output" << std::endl;
 	// live period within each event
 	// maybe redundant here
 	if(f_BDTvars){
@@ -6464,6 +6455,7 @@ void WireCellAnaTree::resetOutput()
     f_WCPMTInfoPePred->clear();
     f_WCPMTInfoPeMeas->clear();
     f_WCPMTInfoPeMeasErr->clear();
+    std::cout << "clearing f_WCPMTInfo variables" << std::endl;
     f_WCPMTInfoTPCClusterID = -1;
     f_WCPMTInfoFlashID = -1;
     f_WCPMTInfoStrength = -1;
@@ -6702,23 +6694,6 @@ void WireCellAnaTree::save_LEEweights(art::Event const& e)
       }
     }
   }
-}
-
-void WireCellAnaTree::ReadWCPMTInfo(nsm::NuSelectionBDT const& bdt)
-{
-  f_WCPMTInfoPePred = bdt.GetWCPMTInfo().WCPMTInfoPePred;
-  f_WCPMTInfoPeMeas = bdt.GetWCPMTInfo().WCPMTInfoPeMeas;
-  f_WCPMTInfoPeMeasErr = bdt.GetWCPMTInfo().WCPMTInfoPeMeasErr;
-  f_WCPMTInfoTPCClusterID = bdt.GetWCPMTInfo().WCPMTInfoTPCClusterID;
-  f_WCPMTInfoFlashID = bdt.GetWCPMTInfo().WCPMTInfoFlashID;
-  f_WCPMTInfoStrength = bdt.GetWCPMTInfo().WCPMTInfoStrength;
-  f_WCPMTInfoEventType = bdt.GetWCPMTInfo().WCPMTInfoEventType;
-  f_WCPMTInfoKSDistance = bdt.GetWCPMTInfo().WCPMTInfoKSDistance;
-  f_WCPMTInfoChi2 = bdt.GetWCPMTInfo().WCPMTInfoChi2;
-  f_WCPMTInfoNDF = bdt.GetWCPMTInfo().WCPMTInfoNDF;
-  f_WCPMTInfoClusterLength = bdt.GetWCPMTInfo().WCPMTInfoClusterLength;
-  f_WCPMTInfoNeutrinoType = bdt.GetWCPMTInfo().WCPMTInfoNeutrinoType;
-  f_WCPMTInfoFlashTime = bdt.GetWCPMTInfo().WCPMTInfoFlashTime;
 }
 
 

--- a/ubana/MicroBooNEWireCell/WireCellAnaTree_module.cc
+++ b/ubana/MicroBooNEWireCell/WireCellAnaTree_module.cc
@@ -2472,7 +2472,7 @@ void WireCellAnaTree::initOutput()
     fSpacepoints->Branch("TrueEDep_spacepoints_endz", &TrueEDep_spacepoints_endz);
     fSpacepoints->Branch("TrueEDep_spacepoints_edep", &TrueEDep_spacepoints_edep);
     fSpacepoints->Branch("TrueEDep_spacepoints_pdg", &TrueEDep_spacepoints_pdg);
-  }  
+  }
 
   if (f_savesps){
     fPFeval->Branch("reco_sps_x", &f_sps_x);
@@ -3910,7 +3910,7 @@ void WireCellAnaTree::analyze(art::Event const& e)
 		std::cout<<"WARNING: >1 in-beam matched TPC activity?!" << std::endl;
 		//return;
 	}else{
-                if(containment_vec.size()<1) {
+  if(containment_vec.size()<1) {
                 f_flash_found = false;
                 f_flash_found_asInt = -1;
                 f_flash_time = -1;
@@ -3931,12 +3931,12 @@ void WireCellAnaTree::analyze(art::Event const& e)
                 }
         for(nsm::NuSelectionContainment const& c : containment_vec) {
                 f_flash_found = c.GetFlashFound();
-		            f_flash_found_asInt = f_flash_found? 1:0;
+                f_flash_found_asInt = f_flash_found? 1:0;
                 f_flash_time = c.GetFlashTime();
                 f_flash_measPe = c.GetFlashMeasPe();
                 f_flash_predPe = c.GetFlashPredPe();
                 f_match_found = c.GetMatchFound();
-		            f_match_found_asInt = f_match_found? 1:0;
+                f_match_found_asInt = f_match_found? 1:0;
                 f_match_type = c.GetMatchType();
                 f_match_isFC = c.GetIsFC();
                 f_match_isTgm = c.GetIsTGM();
@@ -3947,7 +3947,7 @@ void WireCellAnaTree::analyze(art::Event const& e)
                 f_match_energy = c.GetEnergy();
                 f_lm_cluster_length = c.GetLength();
                 f_image_fail = c.GetImageFail();
-	}
+  }
 }
 
         auto const& charge_vec = e.getProduct<std::vector<nsm::NuSelectionCharge>>(fChargeLabel);

--- a/ubana/MicroBooNEWireCell/job/run_wcanatree.fcl
+++ b/ubana/MicroBooNEWireCell/job/run_wcanatree.fcl
@@ -84,6 +84,9 @@ physics:
       SaveTclusterSpacePoints: false # this one is especially large, making the resulting ntuple about 14x larger
       SaveTrueEDepSpacePoints: false # this one is especially large, making the resulting ntuple about 5x larger
 
+      # New WC PMT Info
+      SaveWCPMTInfo: true
+
       ShiftOffset: 0 #0 for Run 1, 387.8 for Run 3 before RWM cable change and 118.3 Run 3 after RWM cable change and Run 4
       isRun3: false #is this run 3 (where the RWM cable changed)?
       # various fit parameters for corrections


### PR DESCRIPTION
This PR saves a very small amount of information related to Wire-Cell light flash reconstruction. In particular, this saves the predicted and measured PE counts on each PMT that are used for flash matching (32x2 numbers, plus some other related information about the matching flash). This information could be useful to try to identify out-TPC activity relevant for single photon searches, among other things.

This has been tested locally and on the grid.

This accompanies these PRs: https://github.com/uboone/ubreco/pull/29, https://github.com/uboone/ubobj/pull/4