### PR TITLE
Improve Backtracker Memory Usage

### DIFF
--- a/ubana/MicroBooNEWireCell/WireCellAnaTree_module.cc
+++ b/ubana/MicroBooNEWireCell/WireCellAnaTree_module.cc
@@ -4262,7 +4262,6 @@ void WireCellAnaTree::analyze(art::Event const& e)
              }
 
              if(fRunBackTracking_evt && fMC){
-               // LArCVBackTrack::TruthMatchResults truthMatch = LArCVBackTrack::run_backtracker(prong_vv, *iolcv, *ioll, adc_v);
                LArCVBackTrack::TruthMatchResults truthMatch = LArCVBackTrack::run_backtracker(prong_vv, *mcpg, *mcpm, adc_v);
                reco_truthMatch_pdg[reco_Ntrack-1] = truthMatch.pdg;
                reco_truthMatch_id[reco_Ntrack-1] = truthMatch.tid;


### PR DESCRIPTION
Initialize the Pixel Map and Pixel Graph base class before the loop over reco prongs during backtracking. This prevents memory build up when various info from root files are read

Interactive tests seem to indicate ~10% memory savings. I can submit a separate PR to remove the redundant `run_backtracker` method in [ubcv](https://github.com/uboone/ubcv/blob/ebef43c4a0afbeace6b8afbf8795bd6e6c1ec8f6/ubcv/LArCVImageMaker/LArCVBackTracker.cxx#L94)

I think I am initializing these base classes at the right spot (inside the event loop when the various LArCV I/O managers are also pointing at the same event) in the ntuple maker but @twongjirad should confirm. 