### PR TITLE
'_closestNuCosmicDist' reinitialization in CRTApproachAnalysis_tool.cc

### DIFF
--- a/ubana/searchingfornues/Selection/AnalysisTools/CRTApproachAnalysis_tool.cc
+++ b/ubana/searchingfornues/Selection/AnalysisTools/CRTApproachAnalysis_tool.cc
@@ -314,6 +314,7 @@ namespace analysis
     _run     = std::numeric_limits<int>::min();
     _sub     = std::numeric_limits<int>::min();
     _evt     = std::numeric_limits<int>::min();
+    _closestNuCosmicDist  =  999999999.;
   }
 
   
@@ -416,7 +417,7 @@ namespace analysis
     _nu_cosmic_End_y   = -9999.;
     _nu_cosmic_End_z   = -9999.;
     _nu_cosmic_TrackID = -9999.;
-    _closestNuCosmicDist  =  999999999.;
+    //_closestNuCosmicDist  =  999999999.;
 
     _rand_vtx_x            = -9999.;
     _rand_vtx_y            = -9999.;


### PR DESCRIPTION
Reinitialize _closestNuCosmicDist correctly in CRTApproachAnalysis_tool.cc. Please disregard the previous PR as it was submitted with a branch incompatible with v10_04_07_br. The only change should be in CRTApproachAnalysis_tool.cc