### PR TITLE
Kaon flux spline weight fix

### DIFF
--- a/ubana/TreeReader/job/multisigma_eventweight_microboone_flux.fcl
+++ b/ubana/TreeReader/job/multisigma_eventweight_microboone_flux.fcl
@@ -92,10 +92,10 @@ microboone_eventweight_flux: {
     random_seed: 6
     parameter_list: ["kminus"]
     parameter_sigma: 1 # not used for multisigma
-    multisigmas: [-3, -2, -1, 0, 1, 2, 3]
+    multisigmas: [-1, 0, 1, 2, 3]
     mode: multisigma
     scale_factor: 1
-    number_of_multisims: 7
+    number_of_multisims: 5
     PrimaryHadronGeantCode: -321 # geant code for particle production on Be
     weight_calculator: "MiniBooNE" # Do not use "MicroBooNE" here. This leads to crashes.
                                    # S. Gardiner, 13 January 2020

--- a/ubana/TreeReader/job/multisigma_eventweight_microboone_flux.fcl
+++ b/ubana/TreeReader/job/multisigma_eventweight_microboone_flux.fcl
@@ -19,8 +19,8 @@ microboone_eventweight_flux: {
     nucleontotxsec, nucleonqexsec, nucleoninexsec
   ]
 
-  # SplineVariation is based on sampling from a HARP covariance matrix, doesn't make sense for multisigma or splines
-  # But we include it here anyway in order to build a covariance matrix (potentially eigen-decomposable into splines later)
+  # pion SplineVariation is based on sampling from a HARP covariance matrix, doesn't make sense for multisigma or splines
+  # So, we save samples for making a covariance matrix
   piplus: {
     type: PrimaryHadronSWCentralSplineVariation
     random_seed: 2
@@ -51,39 +51,40 @@ microboone_eventweight_flux: {
     use_MiniBooNE_random_numbers: false
   }
 
+  # kplus FeynmanScaling is based on sampling from covariance matrix, doesn't make sense for multisigma or splines
+  # So, we save samples for making a covariance matrix
   kplus: {
     type: PrimaryHadronFeynmanScaling
-    random_seed: 4
-    parameter_sigma: 1 # not used for multisigma
-    multisigmas: [-3, -2, -1, 0, 1, 2, 3]
-    mode: multisigma
-    number_of_multisims: 7
+    random_seed: 34567
+    parameter_sigma: 1 
+    mode: multisim
+    number_of_multisims: 1000
     PrimaryHadronGeantCode: 321 # geant code for particle production on Be
     weight_calculator: "MicroBooNE" # "MicroBooNE" OR "MiniBooNE"
-    ExternalData: "beamData/ExternalData/BNBExternalData_uBooNE.root"
-    # Uncertainties without SciBooNE Contraint
+    ### Uncertainties without SciBooNE Contraint
     #parameter_list: ["kplusOld"]
     #scale_factor: 2   
-    #ExternalData:"beamData/ExternalData/BNBExternalData_uBooNE_KPlus_withoutSciBooNE.root"
-    # Uncertainties with SciBooNE Constraint
+    #ExternalData:"beamData/ExternalData/BNBExternalData_uBooNE_KPlus_withoutSciBooNE.root"      
+    ### Uncertainties with SciBooNE Constraint
     parameter_list: ["kplus"]
     scale_factor: 1         
     ExternalData:"beamData/ExternalData/BNBExternalData_uBooNE.root"
     use_MiniBooNE_random_numbers: false
   }
 
+  # kzero SanfordWang is based on sampling from covariance matrix, doesn't make sense for multisigma or splines
+  # So, we save samples for making a covariance matrix
   kzero: {
     type: PrimaryHadronSanfordWang
-    random_seed: 5
+    random_seed: 8888
     parameter_list: ["kzero"]
-    parameter_sigma: 1 # not used for multisigma
-    multisigmas: [-3, -2, -1, 0, 1, 2, 3]
-    mode: multisigma
+    parameter_sigma: 1
+    mode: multisim
     scale_factor: 1
-    number_of_multisims: 7
-    PrimaryHadronGeantCode: [130, 310, 311] # geant code for particle production on Be
+    number_of_multisims: 1000
+    PrimaryHadronGeantCode: [130] # MiniBooNE only reweighted GEANT CODE = 10
     weight_calculator: "MicroBooNE" # "MicroBooNE" OR "MiniBooNE"
-    ExternalData: "beamData/ExternalData/BNBExternalData_uBooNE.root"
+    ExternalData:"beamData/ExternalData/BNBExternalData_uBooNE.root"
     use_MiniBooNE_random_numbers: false
   }
 


### PR DESCRIPTION
Removed -3 and -2 sigma kminus PrimaryHadronNormalization, which would cause unphysical negative weights and was causing issues. Changes SanfordWang and FeynmanScaling to multisim, since this is based on covariance matrix sampling that is not compatible with a simple spline.

Fixes issues in the earlier PR https://github.com/uboone/ubana/pull/80.

Companion to PR https://github.com/uboone/ubsim/pull/19.

