### PR TITLE
Open trig fhicl and patch to def_filetype for numi

### DIFF
--- a/ubana/CombinedReco/run_combinedrecotree_run1_dataON_numi_opentrigger.fcl
+++ b/ubana/CombinedReco/run_combinedrecotree_run1_dataON_numi_opentrigger.fcl
@@ -1,0 +1,10 @@
+#include "run_combinedrecotree_run1_dataON.fcl"
+
+physics.filters.nuselection.AnalysisTools.timing.isNuMI: true
+physics.filters.nuselection.AnalysisTools.timing.IsNuMI: true
+
+physics.filters.nuselection.AnalysisTools.default.makeNuMINtuple: true
+
+physics.filters.nuselection.AnalysisTools.timing.isEXT: false
+physics.filters.nuselection.AnalysisTools.timing.isMC: false
+physics.filters.nuselection.AnalysisTools.timing.nstimePMTWFproducer: "doublePMTFilter:OpdetBeamHighGain"

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_nu_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_fhc_nu_overlay.sh
@@ -115,13 +115,10 @@ physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 
 physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
-
-physics.analyzers.wcpselection.no_mcflux: true
-physics.analyzers.wcpselection.get_spill_time: true
+physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
 
 physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
 physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
-
 
 physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
 physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"

--- a/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_nu_overlay.sh
+++ b/ubana/MicroBooNEWireCell/utils/def_filetype_numi_rhc_nu_overlay.sh
@@ -115,15 +115,10 @@ physics.analyzers.wcpselection.IsNuMI:               ${flag_numi}
 physics.analyzers.wcpweights.IsNuMI:                 ${flag_numi}
 
 physics.analyzers.wcpselection.ssmBDT:               ${flag_numi}
-
 physics.analyzers.wcpselection.get_redk2nu_time:     ${flag_numi}
-
-physics.analyzers.wcpselection.no_mcflux: true
-physics.analyzers.wcpselection.get_spill_time: true
 
 physics.analyzers.wcpselection.SaveLeeWeights:       ${flag_SaveLeeWeights}
 physics.analyzers.wcpweights.SaveLeeWeights:         ${flag_SaveLeeWeights}
-
 
 physics.analyzers.wcpselection.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"
 physics.analyzers.wcpweights.FileType: "prodgenie_${beam}${horncur}_${sample_type}_${FT_STREAM}"


### PR DESCRIPTION
Fix to the WireCell def_filetype script for the fhc and rhc nu overlay versions, which had bugs induced in v10_04_07_v23. The fhc version's bug disabled some of the truth information related to the ns timing, which also broke the reconstructed info. Both versions' bugs also disable some of the addition truth information related to the flux. The new fhicl combines the SURPRISE ntuple maker fhicl for open trigger and NuMI, which will allow NuMI open trigger data to be run properly.